### PR TITLE
Avoid committing Postgres build steps to tagged image

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -29,7 +29,6 @@ services:
       - my-net
 
   db_postgres:
-    image: postgres:15.4-bullseye
     hostname: db_postgres
     container_name: lexy-postgres
     restart: always

--- a/docker/postgres/Dockerfile
+++ b/docker/postgres/Dockerfile
@@ -5,8 +5,7 @@ RUN apt-get update
 RUN apt-get install -y git build-essential postgresql-server-dev-15
 
 # Clone and install pg_embedding
-# Make the operation idempotent to avoid issues when Docker reuses partial images
-RUN if [ ! -d "pg_embedding/.git" ]; then git clone https://github.com/neondatabase/pg_embedding.git && echo "Repo cloned"; else echo "Repo exists"; fi
+RUN git clone https://github.com/neondatabase/pg_embedding.git 
 RUN cd pg_embedding && \
     make && \
     make install


### PR DESCRIPTION
# What changed

Avoids committing Postgres build steps to tagged image. 

# Why

We were running into issues with the Postgres container where rebuilds wouldn't be idempotent. This was addressed in #1 by checking for idempotency issues, but that didn't address the core issue.

The core issue is that by specifying `image` in the docker compose file, we'd tag the _built_ image as the source `postgres:15.4-bullseye` image ([docs](https://github.com/compose-spec/compose-spec/blob/master/spec.md#image)).


# Test plan

Running `docker-compose build db_postgres` twice in a row shouldn't lead to any issues.