### PR TITLE
Force docs deploy

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -21,4 +21,5 @@ jobs:
           restore-keys: |
             mkdocs-material-
       - run: pip install mkdocs-material
+      # https://github.com/mkdocs/mkdocs/issues/973
       - run: mkdocs gh-deploy --force -f docs/mkdocs.yml


### PR DESCRIPTION
# What
Force docs deploy as a shortcut to addressing https://github.com/mkdocs/mkdocs/issues/973

# Why

Without it, the following occurs:

<img width="750" alt="Screenshot 2023-10-10 at 11 35 46 AM" src="https://github.com/lexy-ai/lexy/assets/16868939/1b015a98-dd4c-4d63-be3b-170a7058722a">

See also https://github.com/lexy-ai/lexy/pull/7#discussion_r1351130361

# Test plan

Upon merging this into `main`, docs actually successfully deploy.