### PR TITLE
Switched to exclusive use of save_records_to_index

### DIFF
--- a/lexy/api/endpoints/transformers.py
+++ b/lexy/api/endpoints/transformers.py
@@ -6,12 +6,12 @@ from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from lexy.core.celery_app import get_task_info
-from lexy.core.celery_tasks import save_result_to_index
+from lexy.core.celery_tasks import save_records_to_index
 from lexy.db.session import get_session
 from lexy.models.document import Document
 from lexy.models.transformer import Transformer, TransformerCreate, TransformerUpdate
 from lexy.transformers.counter import count_words
-from lexy.transformers.embeddings import get_chunks, just_split, text_embeddings
+from lexy.transformers.embeddings import get_chunks, just_split, text_embeddings, text_embeddings_transformer
 
 
 router = APIRouter()
@@ -107,9 +107,9 @@ async def embed_string(string: str) -> dict:
 async def embed_documents(documents: List[Document], index_id: str = "default_text_embeddings") -> dict:
     tasks = []
     for doc in documents:
-        task = text_embeddings.apply_async(
+        task = text_embeddings_transformer.apply_async(
             args=[doc.content],
-            link=save_result_to_index.s(document_id=doc.document_id, text=doc.content, index_id=index_id)
+            link=save_records_to_index.s(document_id=doc.document_id, text=doc.content, index_id=index_id)
         )
         tasks.append({"task_id": task.id, "document_id": doc.document_id})
     return {"tasks": tasks}

--- a/lexy/core/events.py
+++ b/lexy/core/events.py
@@ -2,7 +2,7 @@ import importlib
 import logging
 
 from lexy.models import Document, TransformerIndexBinding
-from lexy.core.celery_tasks import save_result_to_index, save_records_to_index
+from lexy.core.celery_tasks import save_records_to_index
 from lexy.indexes import index_manager
 
 
@@ -49,9 +49,9 @@ async def generate_tasks_for_document(doc: Document) -> list[dict]:
         task = transformer_func.apply_async(
             args=[doc.content],
             kwargs=binding.transformer_params,
-            link=save_result_to_index.s(document_id=doc.document_id,
-                                        text=doc.content,
-                                        index_id=binding.index_id)
+            link=save_records_to_index.s(document_id=doc.document_id,
+                                         text=doc.content,
+                                         index_id=binding.index_id)
         )
         tasks.append({"task_id": task.id, "document_id": doc.document_id})
 

--- a/lexy/db/sample_data.py
+++ b/lexy/db/sample_data.py
@@ -55,7 +55,7 @@ sample_data = {
     },
     "transformer_1": {
         "transformer_id": "text.embeddings.minilm",
-        "path": "lexy.transformers.embeddings.text_embeddings",
+        "path": "lexy.transformers.embeddings.text_embeddings_transformer",
         "description": "Text embeddings using Hugging Face model 'sentence-transformers/all-MiniLM-L6-v2'"
     },
     "transformer_2": {


### PR DESCRIPTION
# What

This is a follow up to #12 allowing for the use of `save_results_to_index` instead of having to use two different DB tasks to save embeddings and non-embeddings.

- It uses a very inefficient conversion of Numpy arrays to lists
    - Will update this when updating to Pydantic 2.0
- It requires use of `text_embedding_transformer` instead of `text_embedding`
    - The former simply returns the result of the latter as `{'embedding': result}`
    - Need to create a decorator to wrap output with column names as part of a future PR

# Test plan

Following the test plan of #12, adding a new document to the default collection should now generate two tasks, one for text embedding and one for word counts.