### PR TITLE
added lexy_transformer decorator

### DIFF
--- a/lexy/db/sample_data.py
+++ b/lexy/db/sample_data.py
@@ -55,7 +55,7 @@ sample_data = {
     },
     "transformer_1": {
         "transformer_id": "text.embeddings.minilm",
-        "path": "lexy.transformers.embeddings.text_embeddings_transformer",
+        "path": "lexy.transformers.embeddings.text_embeddings",
         "description": "Text embeddings using Hugging Face model 'sentence-transformers/all-MiniLM-L6-v2'"
     },
     "transformer_2": {
@@ -143,7 +143,11 @@ sample_data = {
         "index_id": "default_text_embeddings",
         "description": "Default transformer-index binding",
         "execution_params": {},
-        "transformer_params": {},
+        "transformer_params": {
+            "lexy_index_fields": [
+                "embedding"
+            ]
+        },
         "filters": {}
     }
 }

--- a/lexy/transformers/__init__.py
+++ b/lexy/transformers/__init__.py
@@ -1,0 +1,103 @@
+import functools
+
+from celery import shared_task
+
+
+def lexy_fields(func):
+    """A decorator to assign index field labels to a transformer's return values.
+
+    Args:
+        func: The transformer function to decorate
+
+    Returns:
+        function: The decorated transformer function
+
+    Examples:
+        >>> @lexy_fields
+        ... def add_and_subtract(a, b):
+        ...     return a + b, a - b
+        ...
+        >>> add_and_subtract(5, 3, lexy_fields=["sum", "difference"])
+        {'sum': 8, 'difference': 2}
+        >>> add_and_subtract(5, 3, lexy_fields=["addition", "subtraction"])
+        {'addition': 8, 'subtraction': 2}
+        >>> add_and_subtract(5, 3)
+        (8, 2)
+    """
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        fields = kwargs.pop('lexy_fields', [])
+        results = func(*args, **kwargs)
+
+        # if no lexy fields are provided, return the original results
+        if not fields:
+            return results
+
+        # if the function returns a single value, wrap it in a tuple
+        if not isinstance(results, tuple):
+            results = (results,)
+
+        # check if the number of lexy fields matches the number of results
+        if len(fields) != len(results):
+            raise ValueError(f"Expected {len(fields)} lexy fields ({', '.join(fields)}), "
+                             f"but got {len(results)} return values from '{func.__name__}'.")
+
+        # zip together labels and results and return as a dictionary inside a list
+        return [dict(zip(fields, results))]
+
+    # modify the docstring to include documentation for the "lexy_fields" parameter
+    lexy_doc = "\n\n" \
+               "Lexy Transformer options:\n\n" \
+               "\tlexy_fields: list, optional\n" \
+               "\t    A list of field names to be used for the return values.\n"
+    if func.__doc__:
+        wrapper.__doc__ = func.__doc__ + lexy_doc
+    else:
+        wrapper.__doc__ = lexy_doc
+
+    return wrapper
+
+
+def lexy_transformer(name: str, **task_kwargs):
+    """A decorator to register a transformer function with Lexy.
+
+    Args:
+        name: The name of the transformer. The task will be registered with Celery as "lexy.transformers.{name}"
+        **task_kwargs: Keyword arguments to pass to the Celery task decorator
+    """
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            lexy_index_fields = kwargs.pop('lexy_index_fields', [])
+            results = func(*args, **kwargs)
+
+            # if no index fields are provided, return the original results
+            if not lexy_index_fields:
+                return results
+
+            # if the function returns a single value, wrap it in a tuple
+            if not isinstance(results, tuple):
+                results = (results,)
+
+            # check if the number of index fields matches the number of results
+            if len(lexy_index_fields) != len(results):
+                raise ValueError(f"Expected {len(lexy_index_fields)} index fields ({', '.join(lexy_index_fields)}), "
+                                 f"but got {len(results)} return values from '{func.__name__}'.")
+
+            # zip together labels and results and return as a dictionary inside a list
+            return [dict(zip(lexy_index_fields, results))]
+
+        # modify the docstring to include documentation for the "lexy_index_fields" parameter
+        lexy_doc = "\n\n" \
+                   "Lexy Transformer options:\n\n" \
+                   "\tlexy_index_fields: list, optional\n" \
+                   "\t    A list of index fields to be used for the return values.\n"
+        if func.__doc__:
+            wrapper.__doc__ = func.__doc__ + lexy_doc
+        else:
+            wrapper.__doc__ = lexy_doc
+
+        wrapper = shared_task(name=f"lexy.transformers.{name}", **task_kwargs)(wrapper)
+        return wrapper
+
+    return decorator

--- a/lexy/transformers/counter.py
+++ b/lexy/transformers/counter.py
@@ -1,9 +1,7 @@
-from typing import Any
-
-from celery import shared_task
+from lexy.transformers import lexy_transformer
 
 
-@shared_task(name="lexy.transformers.counter.count_words")
+@lexy_transformer(name="counter.count_words")
 def count_words(text: str) -> dict[str, int]:
     """ Count the number of words in a text.
 
@@ -16,7 +14,6 @@ def count_words(text: str) -> dict[str, int]:
     Examples:
         >>> count_words("This is a test")
         {"This": 1, "is": 1, "a": 1, "test": 1}
-
     """
     counts = {}
     words = text.split(' ')
@@ -28,11 +25,10 @@ def count_words(text: str) -> dict[str, int]:
     return counts
 
 
-@shared_task(name="lexy.transformers.counter.word_counter")
-def word_counter(text: str) -> list[dict[str, Any]]:
+@lexy_transformer(name="counter.word_counter")
+def word_counter(text: str) -> tuple[int, str]:
     """ Testing a transformer. """
     words = text.split()
     word_count = len(words)
     longest_word = max(words, key=len)
-    return [{"word_count": word_count, "longest_word": longest_word}]
-
+    return word_count, longest_word

--- a/lexy/transformers/embeddings.py
+++ b/lexy/transformers/embeddings.py
@@ -1,15 +1,14 @@
-from celery import shared_task
+from lexy.transformers import lexy_transformer
 
 import torch
-from numpy import ndarray
 from sentence_transformers import SentenceTransformer
-from torch import Tensor
+
 
 torch.set_num_threads(1)
 model = SentenceTransformer('sentence-transformers/all-MiniLM-L6-v2')
 
 
-@shared_task(name="lexy.transformers.embeddings.text_embeddings")
+@lexy_transformer(name="text.embeddings.minilm")
 def text_embeddings(sentences: list[str]) -> torch.Tensor:
     """ Embed sentences using SentenceTransformer.
 
@@ -18,27 +17,11 @@ def text_embeddings(sentences: list[str]) -> torch.Tensor:
 
     Returns:
         torch.Tensor: embeddings
-
     """
     return model.encode(sentences, batch_size=len(sentences))
 
 
-@shared_task(name="lexy.transformers.embeddings.text_embeddings_transformer")
-def text_embeddings_transformer(sentences: list[str]) -> list[dict[str, list[Tensor] | ndarray | Tensor]]:
-    """ Embed sentences using SentenceTransformer.
-
-    Args:
-        sentences: list of sentences to embed
-
-    Returns:
-        torch.Tensor: embeddings
-
-    """
-    res = {'embedding': model.encode(sentences, batch_size=len(sentences))}
-    return [res]
-
-
-@shared_task(name="lexy.transformers.embeddings.get_chunks")
+@lexy_transformer(name="embeddings.get_chunks")
 def get_chunks(text, chunk_size=384) -> list[str]:
     """
     Split text into chunks of size chunk_size.
@@ -53,7 +36,6 @@ def get_chunks(text, chunk_size=384) -> list[str]:
     Examples:
         >>> get_chunks("This is a test", chunk_size=2)
         ["This is", "a test"]
-
     """
     chunks = []
     chunk = []
@@ -75,6 +57,6 @@ def get_chunks(text, chunk_size=384) -> list[str]:
     return chunks
 
 
-@shared_task(name="lexy.transformers.embeddings.just_split")
+@lexy_transformer(name="embeddings.just_split")
 def just_split(text: str, n_times=3) -> list:
     return text.split(' ', n_times)


### PR DESCRIPTION
# What

This PR adds the `lexy_transformer` decorator. The decorator can be imported and applied as follows.

```python
from lexy.transformers import lexy_transformer

@lexy_transformer(name="text.embeddings.minilm")
def text_embeddings(sentences: list[str]) -> torch.Tensor:
    ...
```

When applied to a function, the decorator will:
* Register the function as a celery shared task with the name `lexy.transformers.{name}`
* Add the kwarg `lexy_index_fields` to the function signature
    * When run without the argument, the decorated function behaves as it normally would
    * With the argument, the decorated function returns its output with the labels specified in `lexy_index_fields` (see example below)

```python
@lexy_transformer(name="add_and_subtract")
def add_and_subtract(a, b):
    return a + b, a - b

add_and_subtract(5, 3)
# returns (8, 2)

add_and_subtract(5, 3, lexy_index_fields=["sum", "difference"])
# returns [{'sum': 8, 'difference': 2}]
```

# Test plan

Similar to the test plan for #12, though bindings need the additional keyword argument `lexy_index_fields`. 

- Create a new transformer with the following payload:
```json
{
  "transformer_id": "text.counter.word_counter",
  "path": "lexy.transformers.counter.word_counter",
  "description": "Returns count of words and the longest word"
}
```
- Create a new index with the following payload:
```json
{
  "index_id": "word_counts",
  "description": "Word counts",
  "index_table_schema": {},
  "index_fields": {
      "word_count": {"type": "int"}, 
      "longest_word": {"type": "string", "optional": true}
  }
}
```
- Ensure that the index table `zzidx__word_counts` has been created
    - This is a manual step right now, run `lexy.core.events.create_new_index_table('word_counts')`
- Create a new binding with the following payload:
```json
{
  "collection_id": "default",
  "transformer_id": "text.counter.word_counter",
  "index_id": "word_counts",
  "description": "New binding for word counts",
  "execution_params": {},
  "transformer_params": {
    "lexy_index_fields": ["word_count", "longest_word"]
  },
  "filters": {}
}
```

The test should produce tasks for each document in the default collection using the `word_counter` transformer, and save the results in the index table `zzidx__word_counts`. 

- Finally, the existing binding for `default_text_embeddings` (i.e., binding with `id=1`) should be patched with the following payload:
```json
{
  "transformer_params": {
    "lexy_index_fields": ["embedding"]
  }
}
```

Now, any new documents added to the default collection should trigger two jobs, one for each binding.