### PR TITLE
Updated SQLModel to 0.0.11

### DIFF
--- a/lexy/api/endpoints/bindings.py
+++ b/lexy/api/endpoints/bindings.py
@@ -58,24 +58,40 @@ async def get_binding(binding_id: int, session: AsyncSession = Depends(get_sessi
 
 
 @router.patch("/bindings/{binding_id}",
-              response_model=TransformerIndexBinding,
               status_code=status.HTTP_200_OK,
               name="update_binding",
               description="Update a binding")
 async def update_binding(binding_id: int, binding: TransformerIndexBindingUpdate,
-                         session: AsyncSession = Depends(get_session)) -> TransformerIndexBinding:
+                         session: AsyncSession = Depends(get_session)) -> dict:
     result = await session.execute(select(TransformerIndexBinding).where(TransformerIndexBinding.binding_id ==
                                                                          binding_id))
     db_binding = result.scalars().first()
     if not db_binding:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Binding not found")
+    # record status in case it's changed
+    old_status = db_binding.status
+
     update_data = binding.dict(exclude_unset=True)
     for key, value in update_data.items():
         setattr(db_binding, key, value)
     session.add(db_binding)
     await session.commit()
     await session.refresh(db_binding)
-    return db_binding
+
+    # if status has changed, process the binding
+    if db_binding.status == "on" and old_status != "on":
+        # TODO: this portion needs to be updated to reflect time stamps of tasks
+        #  or to simply become part of an init script
+        print(f"Binding status changed from '{old_status}' to 'on' - processing binding")
+        processed_binding, tasks = await process_new_binding(db_binding)
+        # now commit the binding again and refresh it - status should be updated
+        session.add(processed_binding)
+        await session.commit()
+        await session.refresh(processed_binding)
+        response = {"binding": processed_binding, "tasks": tasks}
+        return response
+    else:
+        return db_binding
 
 
 @router.delete("/bindings/{binding_id}",

--- a/lexy/db/init_db.py
+++ b/lexy/db/init_db.py
@@ -8,7 +8,7 @@ from lexy.db.seed import sample_data
 from lexy.db.session import sync_engine
 from lexy import models  # noqa
 # from lexy.indexes import IndexManager
-from lexy.indexes import index_manager
+# from lexy.indexes import index_manager
 
 
 logger = logging.getLogger(__name__)

--- a/lexy/indexes.py
+++ b/lexy/indexes.py
@@ -106,6 +106,28 @@ class IndexManager(object):
             self._db = SyncSessionLocal()
         return self._db
 
+    def get_bindings(self) -> list[TransformerIndexBinding]:
+        """ Get all bindings """
+        bindings = self.db.exec(select(TransformerIndexBinding)).all()
+        return bindings
+
+    def get_binding(self, binding_id: int) -> TransformerIndexBinding:
+        """ Get a binding by id
+
+        Args:
+            binding_id (int): binding id
+
+        Returns:
+            TransformerIndexBinding: binding
+
+        Raises:
+            ValueError: if binding is not found
+        """
+        binding = self.db.exec(select(TransformerIndexBinding).filter(TransformerIndexBinding.binding_id == binding_id)).first()
+        if not binding:
+            raise ValueError(f"Binding {binding_id} not found")
+        return binding
+
     def get_indexes(self) -> list[Index]:
         """ Get all indexes """
         indexes = self.db.exec(select(Index)).all()
@@ -262,6 +284,22 @@ class IndexManager(object):
         self.db.refresh(binding)
         logger.info(f"Switched status for binding {binding}: from '{prev_status}' to '{status}'")
         return binding
+
+    # # TODO: this needs to move into an app initialization script
+    # def process_default_binding(self, default_index_table_name: str = 'zzidx__default_text_embeddings'):
+    #     """ Process default binding """
+    #     if not self.table_exists(default_index_table_name):
+    #         raise Exception(f"Cannot process default binding because default index table {default_index_table_name} "
+    #                         f"does not exist")
+    #     # to get default binding
+    #     default_binding = self.get_binding(binding_id=1)
+    #     processed_binding, tasks = await process_new_binding(binding)
+    #     # now commit the binding again and refresh it - status should be updated
+    #     self.db.add(processed_binding)
+    #     self.db.commit()
+    #     self.db.refresh(processed_binding)
+    #     response = {"binding": processed_binding, "tasks": tasks}
+    #     return response
 
     @staticmethod
     def table_exists(index_table_name: str) -> bool:

--- a/lexy/models/binding.py
+++ b/lexy/models/binding.py
@@ -24,9 +24,9 @@ class TransformerIndexBindingBase(SQLModel):
     index_id: str = Field(default=None, foreign_key="indexes.index_id")
 
     description: Optional[str] = None
-    execution_params: dict[str, Any] = Field(default={}, sa_column=Column(JSONB), nullable=False)
-    transformer_params: dict[str, Any] = Field(default={}, sa_column=Column(JSONB), nullable=False)
-    filters = Field(default={}, sa_column=Column(JSONB), nullable=False)
+    execution_params: dict[str, Any] = Field(default={}, sa_column=Column(JSONB, nullable=False))
+    transformer_params: dict[str, Any] = Field(default={}, sa_column=Column(JSONB, nullable=False))
+    filters = Field(default={}, sa_column=Column(JSONB, nullable=False))
     # # TODO: make this ENUM
     # run_frequency: str = Field(default="daily", nullable=False)
 
@@ -35,12 +35,10 @@ class TransformerIndexBinding(TransformerIndexBindingBase, table=True):
     __tablename__ = "transformer_index_bindings"
     binding_id: int = Field(default=None, primary_key=True)
     created_at: datetime = Field(
-        nullable=False,
-        sa_column=Column(DateTime(timezone=True), server_default=func.now()),
+        sa_column=Column(DateTime(timezone=True), nullable=False, server_default=func.now()),
     )
     updated_at: datetime = Field(
-        nullable=False,
-        sa_column=Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now()),
+        sa_column=Column(DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now()),
     )
     status: str = Field(default=BindingStatus.PENDING, nullable=False)
     collection: Collection = Relationship(back_populates="transformer_index_bindings",

--- a/lexy/models/collection.py
+++ b/lexy/models/collection.py
@@ -19,12 +19,10 @@ class CollectionBase(SQLModel):
 class Collection(CollectionBase, table=True):
     __tablename__ = "collections"
     created_at: datetime = Field(
-        nullable=False,
-        sa_column=Column(DateTime(timezone=True), server_default=func.now()),
+        sa_column=Column(DateTime(timezone=True), nullable=False, server_default=func.now()),
     )
     updated_at: datetime = Field(
-        nullable=False,
-        sa_column=Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now()),
+        sa_column=Column(DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now()),
     )
     documents: list["Document"] = Relationship(back_populates="collection", sa_relationship_kwargs={'lazy': 'subquery'})
     transformer_index_bindings: list["TransformerIndexBinding"] = \

--- a/lexy/models/document.py
+++ b/lexy/models/document.py
@@ -24,12 +24,10 @@ class Document(DocumentBase, table=True):
         nullable=False,
     )
     created_at: datetime = Field(
-        nullable=False,
-        sa_column=Column(DateTime(timezone=True), server_default=func.now()),
+        sa_column=Column(DateTime(timezone=True), nullable=False, server_default=func.now()),
     )
     updated_at: datetime = Field(
-        nullable=False,
-        sa_column=Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now()),
+        sa_column=Column(DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now()),
     )
     collection_id: str = Field(default="default", foreign_key="collections.collection_id")
     collection: Collection = Relationship(back_populates="documents", sa_relationship_kwargs={'lazy': 'selectin'})

--- a/lexy/models/embedding.py
+++ b/lexy/models/embedding.py
@@ -27,12 +27,10 @@ class Embedding(EmbeddingBase, table=True):
         nullable=False,
     )
     created_at: datetime = Field(
-        nullable=False,
-        sa_column=Column(DateTime(timezone=True), server_default=func.now()),
+        sa_column=Column(DateTime(timezone=True), nullable=False, server_default=func.now()),
     )
     updated_at: datetime = Field(
-        nullable=False,
-        sa_column=Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now()),
+        sa_column=Column(DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now()),
     )
     document: Document = Relationship(back_populates="embeddings")
     task_id: Optional[UUID] = Field(default=None)

--- a/lexy/models/index.py
+++ b/lexy/models/index.py
@@ -19,26 +19,22 @@ class IndexBase(SQLModel):
         regex=r"^[a-z0-9_-]+$"
     )
     description: Optional[str] = None
-    index_table_schema: Optional[dict[str, Any]] = Field(sa_column=Column(JSON), nullable=False, default={})
-    index_fields: Optional[dict[str, Any]] = Field(sa_column=Column(JSON), nullable=False, default={})
+    index_table_schema: Optional[dict[str, Any]] = Field(sa_column=Column(JSON, nullable=False), default={})
+    index_fields: Optional[dict[str, Any]] = Field(sa_column=Column(JSON, nullable=False), default={})
 
 
 class Index(IndexBase, table=True):
     __tablename__ = "indexes"
     created_at: datetime = Field(
-        nullable=False,
-        sa_column=Column(DateTime(timezone=True), server_default=func.now()),
+        sa_column=Column(DateTime(timezone=True), nullable=False, server_default=func.now()),
     )
     updated_at: datetime = Field(
-        nullable=False,
-        sa_column=Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now()),
+        sa_column=Column(DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now()),
     )
     transformer_bindings: list["TransformerIndexBinding"] = Relationship(back_populates="index")
     index_table_name: str = Field(
-        nullable=False,
         regex=r"^[a-z0-9_-]+$",
-        sa_column=Column(String, default=default_index_table_name),
-        unique=True
+        sa_column=Column(String, default=default_index_table_name, nullable=False, unique=True),
     )
 
 

--- a/lexy/models/index_record.py
+++ b/lexy/models/index_record.py
@@ -2,13 +2,16 @@ from datetime import datetime
 from typing import Any, Optional
 from uuid import uuid4, UUID
 
-from sqlalchemy import Column, DateTime, func
+from sqlalchemy import Column, DateTime, ForeignKey, func
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlmodel import SQLModel, Field, Relationship
 
 
 class IndexRecordBase(SQLModel):
-    document_id: UUID = Field(foreign_key="documents.document_id", index=True)
+    document_id: Optional[UUID] = Field(
+        sa_column_args=(ForeignKey('documents.document_id', ondelete='CASCADE'),),
+        index=True,
+        nullable=True)
     custom_id: Optional[str] = Field(default=None)
     meta: Optional[dict[Any, Any]] = Field(sa_column=Column(JSONB), default={})
 
@@ -30,12 +33,10 @@ class IndexRecordBaseTable(IndexRecordBase):
         nullable=False,
     )
     created_at: datetime = Field(
-        nullable=False,
-        sa_column=Column(DateTime(timezone=True), server_default=func.now()),
+        sa_column=Column(DateTime(timezone=True), nullable=False, server_default=func.now()),
     )
     updated_at: datetime = Field(
-        nullable=False,
-        sa_column=Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now()),
+        sa_column=Column(DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now()),
     )
     document: "Document" = Relationship(back_populates="index_records")
     task_id: Optional[UUID] = Field(default=None)

--- a/lexy/models/transformer.py
+++ b/lexy/models/transformer.py
@@ -25,12 +25,10 @@ class TransformerBase(SQLModel):
 class Transformer(TransformerBase, table=True):
     __tablename__ = "transformers"
     created_at: datetime = Field(
-        nullable=False,
-        sa_column=Column(DateTime(timezone=True), server_default=func.now()),
+        sa_column=Column(DateTime(timezone=True), nullable=False, server_default=func.now()),
     )
     updated_at: datetime = Field(
-        nullable=False,
-        sa_column=Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now()),
+        sa_column=Column(DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now()),
     )
     index_bindings: list["TransformerIndexBinding"] = Relationship(back_populates="transformer")
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -2068,18 +2068,18 @@ typing-extensions = ">=3.7.4"
 
 [[package]]
 name = "sqlmodel"
-version = "0.0.8"
+version = "0.0.11"
 description = "SQLModel, SQL databases in Python, designed for simplicity, compatibility, and robustness."
 optional = false
-python-versions = ">=3.6.1,<4.0.0"
+python-versions = ">=3.7,<4.0"
 files = [
-    {file = "sqlmodel-0.0.8-py3-none-any.whl", hash = "sha256:0fd805719e0c5d4f22be32eb3ffc856eca3f7f20e8c7aa3e117ad91684b518ee"},
-    {file = "sqlmodel-0.0.8.tar.gz", hash = "sha256:3371b4d1ad59d2ffd0c530582c2140b6c06b090b32af9b9c6412986d7b117036"},
+    {file = "sqlmodel-0.0.11-py3-none-any.whl", hash = "sha256:bc0d64c4b901d919d2f16bbd79aefb07cb268c29f7c1dd83a84758772ccc95c6"},
+    {file = "sqlmodel-0.0.11.tar.gz", hash = "sha256:fc33abbf7ec29caafabe3d0e1db61e33597857a289e5fd1ecdb91be702b26084"},
 ]
 
 [package.dependencies]
-pydantic = ">=1.8.2,<2.0.0"
-SQLAlchemy = ">=1.4.17,<=1.4.41"
+pydantic = ">=1.9.0,<2.0.0"
+SQLAlchemy = ">=1.4.36,<2.0.0"
 sqlalchemy2-stubs = "*"
 
 [[package]]
@@ -2502,4 +2502,4 @@ lexy-transformers = ["sentence-transformers", "transformers"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "135d41fd8ecbdad789d40ba7379299bd88d8714504fb190d90a9e2f2cb1a8402"
+content-hash = "1fddd5845c16c7c7dac7553094fe9bf926a2625cb61c0a69a6ce3c013551374e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 [tool.poetry.dependencies]
 python = "^3.10"
 fastapi = "^0.103.0"
-sqlmodel = "^0.0.8"
+sqlmodel = "^0.0.11"
 psycopg2-binary = "^2.9.7"
 asyncpg = "^0.28.0"
 uvicorn = "^0.23.2"


### PR DESCRIPTION
# What

This updates SQLModel to version 0.0.11, which solves an [issue](https://github.com/tiangolo/sqlmodel/pull/443) with foreign key declaration, and another [issue](https://github.com/tiangolo/sqlmodel/pull/58) with AsyncSession type annotations.

# Why

Prior to this update, attempting to delete a document with an associated index record would throw a foreign key violation error.


# Test plan

Add a document which results in an index record being created. Delete the same document and verify that 

- The document is deleted without error
- The index records associated with the document are also deleted