### PR TITLE
Updated Python SDK

### DIFF
--- a/examples/tests.ipynb
+++ b/examples/tests.ipynb
@@ -1,0 +1,1223 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "source": [
+    "# Lexy client"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "outputs": [],
+   "source": [
+    "from lexy_py.client import LexyClient\n",
+    "\n",
+    "lexy = LexyClient()"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-11-08T01:02:00.794046Z",
+     "start_time": "2023-11-08T01:02:00.621451Z"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "outputs": [],
+   "source": [
+    "import inspect\n",
+    "import pytest"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-11-08T01:02:00.794715Z",
+     "start_time": "2023-11-08T01:02:00.700773Z"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "# Collections"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### List collections"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "[<Collection('default', description=Default collection)>,\n <Collection('code', description=Github code repos)>,\n <Collection('texts', description=Text messages)>]"
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "lexy.collection.list_collections()"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-11-08T01:02:00.795429Z",
+     "start_time": "2023-11-08T01:02:00.733535Z"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Get collection"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "<Collection('default', description=Default collection)>"
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "default_collection = lexy.collection.get_collection('default')\n",
+    "default_collection"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-11-08T01:02:00.795624Z",
+     "start_time": "2023-11-08T01:02:00.766286Z"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "[<Document(\"This is my first document! It's great!\", ddbaef54-abee-48b2-b1d6-45d1d0f65812)>,\n <Document(\"Meh. This one is just ok.\", 732492b3-3c1e-4692-9693-ce4904eb5691)>,\n <Document(\"Starlink is a satellite internet constellation operated by American aerospace company SpaceX,...\", 4d605d42-94df-423b-bb96-ee41c521760f)>,\n <Document(\"A latent space, also known as a latent feature space or embedding space, is an embedding of a set...\", fa15ee1a-a546-4cb4-9699-4457cf0a9f6f)>,\n <Document(\"ray is an open source framework\", 0375fa39-fa05-4547-a05e-c5cab8980580)>]"
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "default_docs = default_collection.list_documents()\n",
+    "default_docs[:5]"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-11-08T01:02:00.795769Z",
+     "start_time": "2023-11-08T01:02:00.776923Z"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "<Document(\"This is my first document! It's great!\", ddbaef54-abee-48b2-b1d6-45d1d0f65812)>"
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "doc = default_docs[0]\n",
+    "doc"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-11-08T01:02:00.795936Z",
+     "start_time": "2023-11-08T01:02:00.786044Z"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Create a new collection"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "outputs": [],
+   "source": [
+    "from lexy_py.collection.models import Collection"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-11-08T01:02:00.796024Z",
+     "start_time": "2023-11-08T01:02:00.791038Z"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(*, collection_id: lexy_py.collection.models.ConstrainedStrValue, description: Optional[str] = None, created_at: Optional[datetime.datetime] = None, updated_at: Optional[datetime.datetime] = None) -> None\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(inspect.signature(Collection))"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-11-08T01:02:00.796097Z",
+     "start_time": "2023-11-08T01:02:00.791105Z"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "<Collection('notbeingcreated', description=None)>"
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "collection_without_a_client = Collection(collection_id='notbeingcreated')\n",
+    "collection_without_a_client"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-11-08T01:02:00.796186Z",
+     "start_time": "2023-11-08T01:02:00.792698Z"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<ExceptionInfo ValueError('API client has not been set.') tblen=3>\n"
+     ]
+    }
+   ],
+   "source": [
+    "with pytest.raises(ValueError) as exc_info:\n",
+    "    collection_without_a_client.list_documents()\n",
+    "print(exc_info)\n",
+    "assert isinstance(exc_info.value, ValueError)\n",
+    "assert str(exc_info.value) == \"API client has not been set.\""
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-11-08T01:02:00.804879Z",
+     "start_time": "2023-11-08T01:02:00.795811Z"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "<Collection('junk', description=just testing for now)>"
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "new_collection = lexy.collection.add_collection(collection_id='junk', description='just testing for now')\n",
+    "new_collection"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-11-08T01:02:00.878542Z",
+     "start_time": "2023-11-08T01:02:00.798440Z"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "[<Collection('default', description=Default collection)>,\n <Collection('code', description=Github code repos)>,\n <Collection('texts', description=Text messages)>,\n <Collection('junk', description=just testing for now)>]"
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "lexy.collection.list_collections()"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-11-08T01:02:00.883164Z",
+     "start_time": "2023-11-08T01:02:00.850396Z"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "[]"
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "new_collection.list_documents()"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-11-08T01:02:00.883300Z",
+     "start_time": "2023-11-08T01:02:00.865850Z"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "{'Say': 'Collection deleted!'}"
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "lexy.collection.delete_collection('junk')"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-11-08T01:02:00.923012Z",
+     "start_time": "2023-11-08T01:02:00.869161Z"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "[<Collection('default', description=Default collection)>,\n <Collection('code', description=Github code repos)>,\n <Collection('texts', description=Text messages)>]"
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "lexy.collection.list_collections()"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-11-08T01:02:00.929562Z",
+     "start_time": "2023-11-08T01:02:00.918354Z"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "# Documents"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### List documents"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "[<Document(\"This is my first document! It's great!\", ddbaef54-abee-48b2-b1d6-45d1d0f65812)>,\n <Document(\"Meh. This one is just ok.\", 732492b3-3c1e-4692-9693-ce4904eb5691)>,\n <Document(\"Starlink is a satellite internet constellation operated by American aerospace company SpaceX,...\", 4d605d42-94df-423b-bb96-ee41c521760f)>,\n <Document(\"A latent space, also known as a latent feature space or embedding space, is an embedding of a set...\", fa15ee1a-a546-4cb4-9699-4457cf0a9f6f)>,\n <Document(\"ray is an open source framework\", 0375fa39-fa05-4547-a05e-c5cab8980580)>]"
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "lexy.document.list_documents()[:5]"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-11-08T01:02:00.938364Z",
+     "start_time": "2023-11-08T01:02:00.930244Z"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "[<Document(\"import this\", 20984c80-2a3c-475d-af59-45864762fc73)>,\n <Document(\"def multiply(a, b): return a * bif __name__ == '__main__': print(multiply(2, 3))\", 1a9317e5-0d1f-4c7f-b731-42bddf0f4c98)>]"
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "code_docs = lexy.document.list_documents('code')\n",
+    "code_docs"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-11-08T01:02:00.988119Z",
+     "start_time": "2023-11-08T01:02:00.938529Z"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "<Document(\"import this\", 20984c80-2a3c-475d-af59-45864762fc73)>"
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "code_doc = code_docs[0]\n",
+    "code_doc"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-11-08T01:02:00.991143Z",
+     "start_time": "2023-11-08T01:02:00.989261Z"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "outputs": [],
+   "source": [
+    "assert isinstance(code_doc.client, LexyClient)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-11-08T01:02:00.992882Z",
+     "start_time": "2023-11-08T01:02:00.991792Z"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Get document"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "<Document(\"import this\", 20984c80-2a3c-475d-af59-45864762fc73)>"
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sample_doc = lexy.document.get_document('20984c80-2a3c-475d-af59-45864762fc73')\n",
+    "sample_doc"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-11-08T01:02:01.000651Z",
+     "start_time": "2023-11-08T01:02:00.994099Z"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "{'document_id': '20984c80-2a3c-475d-af59-45864762fc73',\n 'content': 'import this',\n 'meta': {'filename': 'main.py', 'language': 'python', 'file_extension': 'py'},\n 'created_at': datetime.datetime(2023, 11, 3, 21, 40, 23, 948372, tzinfo=datetime.timezone.utc),\n 'updated_at': datetime.datetime(2023, 11, 3, 21, 40, 23, 948372, tzinfo=datetime.timezone.utc),\n 'collection_id': 'code'}"
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sample_doc.dict()"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-11-08T01:02:01.003752Z",
+     "start_time": "2023-11-08T01:02:01.000763Z"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "outputs": [],
+   "source": [
+    "assert isinstance(sample_doc.client, LexyClient)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-11-08T01:02:01.005716Z",
+     "start_time": "2023-11-08T01:02:01.004280Z"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Create new document"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "outputs": [],
+   "source": [
+    "from lexy_py.document.models import Document"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-11-08T01:02:01.034203Z",
+     "start_time": "2023-11-08T01:02:01.006222Z"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(content: str, *, document_id: Optional[str] = None, meta: Optional[dict[Any, Any]] = {}, created_at: Optional[datetime.datetime] = None, updated_at: Optional[datetime.datetime] = None, collection_id: Optional[str] = None) -> None\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(inspect.signature(Document))"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-11-08T01:02:01.034670Z",
+     "start_time": "2023-11-08T01:02:01.008543Z"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "<Document(\"this is a new doc\", None)>"
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Document(\"this is a new doc\")"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-11-08T01:02:01.035056Z",
+     "start_time": "2023-11-08T01:02:01.011369Z"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "[{'document': {'updated_at': '2023-11-08T01:02:01.015371+00:00',\n   'created_at': '2023-11-08T01:02:01.015371+00:00',\n   'document_id': 'afe30284-6d0e-4a39-af91-e12a22d97626',\n   'meta': {},\n   'content': 'This is my shiny new document!',\n   'collection_id': 'default'},\n  'tasks': [{'task_id': 'b09250d0-9390-4b9d-a5dd-92e6be0cc33a',\n    'document_id': 'afe30284-6d0e-4a39-af91-e12a22d97626'},\n   {'task_id': '20b854b0-1e70-489a-bc6c-ff9516450599',\n    'document_id': 'afe30284-6d0e-4a39-af91-e12a22d97626'}]}]"
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "new_doc_response = lexy.document.add_documents([\n",
+    "    {'content': 'This is my shiny new document!'}\n",
+    "])\n",
+    "new_doc_response"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-11-08T01:02:01.035216Z",
+     "start_time": "2023-11-08T01:02:01.013517Z"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "<Document(\"This is my shiny new document!\", afe30284-6d0e-4a39-af91-e12a22d97626)>"
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "new_doc = Document(**new_doc_response[0]['document'], client=lexy)\n",
+    "new_doc"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-11-08T01:02:01.036032Z",
+     "start_time": "2023-11-08T01:02:01.030259Z"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "{'Say': 'Document deleted!'}"
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "lexy.document.delete_document(document_id=new_doc.document_id)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-11-08T01:02:01.101414Z",
+     "start_time": "2023-11-08T01:02:01.034411Z"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "# Indexes"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### List indexes"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "[<Index('default_text_embeddings', description='Text embeddings for default collection')>,\n <Index('word_counts', description='Word counts')>,\n <Index('ex_index', description='Text and metadata')>]"
+     },
+     "execution_count": 29,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "lexy.index.list_indexes()"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-11-08T01:02:01.113349Z",
+     "start_time": "2023-11-08T01:02:01.089316Z"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Get index"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "<Index('default_text_embeddings', description='Text embeddings for default collection')>"
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "idx = lexy.index.get_index('default_text_embeddings')\n",
+    "idx"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-11-08T01:02:01.113727Z",
+     "start_time": "2023-11-08T01:02:01.101580Z"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "[{'document_id': '732492b3-3c1e-4692-9693-ce4904eb5691',\n  'custom_id': None,\n  'meta': {},\n  'index_record_id': 'bf5d156b-7b1f-43ed-841f-725ea6cd9e8e',\n  'document_content': 'Meh. This one is just ok.',\n  'abs_distance': 1.2701034545898438,\n  'distance': 1.2701034545898438,\n  'text': 'Meh. This one is just ok.'},\n {'document_id': 'ddbaef54-abee-48b2-b1d6-45d1d0f65812',\n  'custom_id': None,\n  'meta': {},\n  'index_record_id': '36b9a917-9cb7-479f-a7bd-84a8f12d3b94',\n  'document_content': \"This is my first document! It's great!\",\n  'abs_distance': 1.2820980548858643,\n  'distance': 1.2820980548858643,\n  'text': \"This is my first document! It's great!\"},\n {'document_id': '0375fa39-fa05-4547-a05e-c5cab8980580',\n  'custom_id': None,\n  'meta': {},\n  'index_record_id': 'fc0d3d54-2717-4f1c-ade9-4bd0e7976a78',\n  'document_content': 'ray is an open source framework',\n  'abs_distance': 1.3046300411224365,\n  'distance': 1.3046300411224365,\n  'text': 'ray is an open source framework'},\n {'document_id': '4d605d42-94df-423b-bb96-ee41c521760f',\n  'custom_id': None,\n  'meta': {},\n  'index_record_id': '473d6276-a20c-40ee-8829-eebe6ad82cb8',\n  'document_content': 'Starlink is a satellite internet constellation operated by American aerospace company SpaceX, providing coverage to over 60 countries.',\n  'abs_distance': 1.3691524267196655,\n  'distance': 1.3691524267196655,\n  'text': 'Starlink is a satellite internet constellation operated by American aerospace company SpaceX, providing coverage to over 60 countries.'},\n {'document_id': 'fa15ee1a-a546-4cb4-9699-4457cf0a9f6f',\n  'custom_id': None,\n  'meta': {},\n  'index_record_id': 'd04af35a-d43f-48a9-a5d5-81be7e1be770',\n  'document_content': 'A latent space, also known as a latent feature space or embedding space, is an embedding of a set of items within a manifold in which items resembling each other are positioned closer to one another.',\n  'abs_distance': 1.3917694091796875,\n  'distance': 1.3917694091796875,\n  'text': 'A latent space, also known as a latent feature space or embedding space, is an embedding of a set of items within a manifold in which items resembling each other are positioned closer to one another.'}]"
+     },
+     "execution_count": 31,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "idx.query('hello world')"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-11-08T01:02:01.641690Z",
+     "start_time": "2023-11-08T01:02:01.111947Z"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Create new index"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "outputs": [],
+   "source": [
+    "from lexy_py.index.models import Index"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-11-08T01:02:01.643362Z",
+     "start_time": "2023-11-08T01:02:01.641885Z"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(*, index_id: lexy_py.index.models.ConstrainedStrValue, description: Optional[str] = None, index_table_schema: Optional[dict[str, Any]] = {}, index_fields: Optional[dict[str, Any]] = {}, created_at: Optional[datetime.datetime] = None, updated_at: Optional[datetime.datetime] = None, index_table_name: Optional[str] = None) -> None\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(inspect.signature(Index))"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-11-08T01:02:01.646819Z",
+     "start_time": "2023-11-08T01:02:01.644481Z"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "outputs": [],
+   "source": [
+    "# TODO: implement this after setting up mock (do not run against live server)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-11-08T01:02:01.648867Z",
+     "start_time": "2023-11-08T01:02:01.647030Z"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "# Bindings"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### List bindings"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "[<TransformerIndexBinding id=1, status=ON, collection_id=default, transformer_id=text.embeddings.minilm, index_id=default_text_embeddings>,\n <TransformerIndexBinding id=2, status=ON, collection_id=default, transformer_id=text.counter.word_counter, index_id=word_counts>,\n <TransformerIndexBinding id=3, status=ON, collection_id=texts, transformer_id=text.counter.word_counter, index_id=ex_index>]"
+     },
+     "execution_count": 35,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "lexy.binding.list_bindings()"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-11-08T01:02:01.711696Z",
+     "start_time": "2023-11-08T01:02:01.649072Z"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Get binding"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "<TransformerIndexBinding id=1, status=ON, collection_id=default, transformer_id=text.embeddings.minilm, index_id=default_text_embeddings>"
+     },
+     "execution_count": 36,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "binding = lexy.binding.get_binding(1)\n",
+    "binding"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-11-08T01:02:01.726399Z",
+     "start_time": "2023-11-08T01:02:01.661828Z"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "<Collection('default', description=Default collection)>"
+     },
+     "execution_count": 37,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "binding.collection"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-11-08T01:02:01.726545Z",
+     "start_time": "2023-11-08T01:02:01.689431Z"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "'Default collection'"
+     },
+     "execution_count": 38,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "binding.collection.description"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-11-08T01:02:01.726624Z",
+     "start_time": "2023-11-08T01:02:01.689504Z"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "<Transformer('text.embeddings.minilm', description='Text embeddings using Hugging Face model 'sentence-transformers/all-MiniLM-L6-v2'')>"
+     },
+     "execution_count": 39,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "binding.transformer"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-11-08T01:02:01.726719Z",
+     "start_time": "2023-11-08T01:02:01.693501Z"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "<Index('default_text_embeddings', description='Text embeddings for default collection')>"
+     },
+     "execution_count": 40,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "binding.index"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-11-08T01:02:01.726780Z",
+     "start_time": "2023-11-08T01:02:01.696380Z"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "'Text embeddings for default collection'"
+     },
+     "execution_count": 41,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "binding.index.description"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-11-08T01:02:01.726871Z",
+     "start_time": "2023-11-08T01:02:01.704119Z"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "[{'document_id': 'ddbaef54-abee-48b2-b1d6-45d1d0f65812',\n  'custom_id': None,\n  'meta': {},\n  'index_record_id': '36b9a917-9cb7-479f-a7bd-84a8f12d3b94',\n  'document_content': \"This is my first document! It's great!\",\n  'abs_distance': 1.2729943990707397,\n  'distance': 1.2729943990707397,\n  'text': \"This is my first document! It's great!\"},\n {'document_id': '0375fa39-fa05-4547-a05e-c5cab8980580',\n  'custom_id': None,\n  'meta': {},\n  'index_record_id': 'fc0d3d54-2717-4f1c-ade9-4bd0e7976a78',\n  'document_content': 'ray is an open source framework',\n  'abs_distance': 1.2912185192108154,\n  'distance': 1.2912185192108154,\n  'text': 'ray is an open source framework'},\n {'document_id': '732492b3-3c1e-4692-9693-ce4904eb5691',\n  'custom_id': None,\n  'meta': {},\n  'index_record_id': 'bf5d156b-7b1f-43ed-841f-725ea6cd9e8e',\n  'document_content': 'Meh. This one is just ok.',\n  'abs_distance': 1.3080474138259888,\n  'distance': 1.3080474138259888,\n  'text': 'Meh. This one is just ok.'},\n {'document_id': '4d605d42-94df-423b-bb96-ee41c521760f',\n  'custom_id': None,\n  'meta': {},\n  'index_record_id': '473d6276-a20c-40ee-8829-eebe6ad82cb8',\n  'document_content': 'Starlink is a satellite internet constellation operated by American aerospace company SpaceX, providing coverage to over 60 countries.',\n  'abs_distance': 1.3754034042358398,\n  'distance': 1.3754034042358398,\n  'text': 'Starlink is a satellite internet constellation operated by American aerospace company SpaceX, providing coverage to over 60 countries.'},\n {'document_id': 'fa15ee1a-a546-4cb4-9699-4457cf0a9f6f',\n  'custom_id': None,\n  'meta': {},\n  'index_record_id': 'd04af35a-d43f-48a9-a5d5-81be7e1be770',\n  'document_content': 'A latent space, also known as a latent feature space or embedding space, is an embedding of a set of items within a manifold in which items resembling each other are positioned closer to one another.',\n  'abs_distance': 1.411808967590332,\n  'distance': 1.411808967590332,\n  'text': 'A latent space, also known as a latent feature space or embedding space, is an embedding of a set of items within a manifold in which items resembling each other are positioned closer to one another.'}]"
+     },
+     "execution_count": 42,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "binding.index.query('hi')"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-11-08T01:02:02.240453Z",
+     "start_time": "2023-11-08T01:02:01.711845Z"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "[<Document(\"This is my first document! It's great!\", ddbaef54-abee-48b2-b1d6-45d1d0f65812)>,\n <Document(\"Meh. This one is just ok.\", 732492b3-3c1e-4692-9693-ce4904eb5691)>,\n <Document(\"Starlink is a satellite internet constellation operated by American aerospace company SpaceX,...\", 4d605d42-94df-423b-bb96-ee41c521760f)>,\n <Document(\"A latent space, also known as a latent feature space or embedding space, is an embedding of a set...\", fa15ee1a-a546-4cb4-9699-4457cf0a9f6f)>,\n <Document(\"ray is an open source framework\", 0375fa39-fa05-4547-a05e-c5cab8980580)>]"
+     },
+     "execution_count": 43,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "binding.collection.list_documents()[:5]"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-11-08T01:02:02.248043Z",
+     "start_time": "2023-11-08T01:02:02.240745Z"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "outputs": [],
+   "source": [
+    "assert isinstance(binding.collection.client, LexyClient)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-11-08T01:02:02.249639Z",
+     "start_time": "2023-11-08T01:02:02.248903Z"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Create new binding"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
+   "outputs": [],
+   "source": [
+    "from lexy_py.binding.models import TransformerIndexBinding"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-11-08T01:02:02.251785Z",
+     "start_time": "2023-11-08T01:02:02.250734Z"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 46,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(*, binding_id: Optional[int] = None, collection_id: Optional[str] = None, transformer_id: Optional[str] = None, index_id: Optional[str] = None, created_at: Optional[datetime.datetime] = None, updated_at: Optional[datetime.datetime] = None, description: Optional[str] = None, execution_params: Optional[dict[str, Any]] = {}, transformer_params: Optional[dict[str, Any]] = {}, filters: Optional[dict] = {}, status: Optional[lexy_py.binding.models.BindingStatus] = <BindingStatus.PENDING: 'pending'>, collection: Optional[lexy_py.collection.models.CollectionModel] = None, transformer: Optional[lexy_py.transformer.models.TransformerModel] = None, index: Optional[lexy_py.index.models.IndexModel] = None) -> None\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(inspect.signature(TransformerIndexBinding))"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-11-08T01:02:02.254266Z",
+     "start_time": "2023-11-08T01:02:02.252713Z"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 47,
+   "outputs": [],
+   "source": [
+    "# TODO: implement this after setting up mock (do not run against live server)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2023-11-08T01:02:02.256Z",
+     "start_time": "2023-11-08T01:02:02.254822Z"
+    }
+   }
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/lexy/api/endpoints/bindings.py
+++ b/lexy/api/endpoints/bindings.py
@@ -6,7 +6,8 @@ from lexy.db.session import get_session
 from lexy.models.binding import (
     TransformerIndexBinding,
     TransformerIndexBindingCreate,
-    TransformerIndexBindingUpdate
+    TransformerIndexBindingUpdate,
+    TransformerIndexBindingRead
 )
 from lexy.core.events import process_new_binding
 
@@ -15,11 +16,11 @@ router = APIRouter()
 
 
 @router.get("/bindings",
-            response_model=list[TransformerIndexBinding],
+            response_model=list[TransformerIndexBindingRead],
             status_code=status.HTTP_200_OK,
             name="get_bindings",
             description="Get all bindings")
-async def get_bindings(session: AsyncSession = Depends(get_session)) -> list[TransformerIndexBinding]:
+async def get_bindings(session: AsyncSession = Depends(get_session)) -> list[TransformerIndexBindingRead]:
     result = await session.execute(select(TransformerIndexBinding))
     bindings = result.scalars().all()
     return bindings
@@ -44,11 +45,11 @@ async def add_binding(binding: TransformerIndexBindingCreate, session: AsyncSess
 
 
 @router.get("/bindings/{binding_id}",
-            response_model=TransformerIndexBinding,
+            response_model=TransformerIndexBindingRead,
             status_code=status.HTTP_200_OK,
             name="get_binding",
             description="Get a binding")
-async def get_binding(binding_id: int, session: AsyncSession = Depends(get_session)) -> TransformerIndexBinding:
+async def get_binding(binding_id: int, session: AsyncSession = Depends(get_session)) -> TransformerIndexBindingRead:
     result = await session.execute(select(TransformerIndexBinding).where(TransformerIndexBinding.binding_id ==
                                                                          binding_id))
     binding = result.scalars().first()

--- a/lexy/core/celery_app.py
+++ b/lexy/core/celery_app.py
@@ -19,7 +19,12 @@ def create_celery():
     # serialization settings
     celery_app.conf.update(task_serializer='pickle')
     celery_app.conf.update(result_serializer='pickle')
-    celery_app.conf.update(accept_content=['pickle', 'json', 'application/json'])
+    celery_app.conf.update(accept_content=[
+        'pickle',
+        'json',
+        'application/json',
+        # 'application/x-python-serialize',  # adding for flower
+    ])
 
     # celery_app.conf.update(result_expires=200)
     celery_app.conf.update(result_persistent=True)

--- a/lexy/models/binding.py
+++ b/lexy/models/binding.py
@@ -66,3 +66,14 @@ class TransformerIndexBindingUpdate(TransformerIndexBindingBase):
     transformer_params: Optional[dict[str, Any]] = None
     filters: Optional[dict[str, Any]] = None
     status: Optional[str] = None
+
+
+class TransformerIndexBindingRead(TransformerIndexBindingBase):
+    binding_id: int
+    created_at: datetime
+    updated_at: datetime
+    status: str
+    collection: Collection
+    transformer: Transformer
+    index: Index
+

--- a/sdk-python/README.md
+++ b/sdk-python/README.md
@@ -24,7 +24,7 @@ lexy.document.add_documents([
 ### Query index
 
 ```python
-lexy.index.query_index("default_text_embeddings", "test query", k=5)
+lexy.index.query_index("test query", "default_text_embeddings", k=5)
 ```
 
 ## Testing

--- a/sdk-python/lexy_py/binding/client.py
+++ b/sdk-python/lexy_py/binding/client.py
@@ -1,11 +1,14 @@
 """ Client for interacting with the Bindings API. """
 
-from typing import Optional
+from typing import Optional, TYPE_CHECKING
 
 import httpx
 
 from lexy_py.exceptions import handle_response
 from .models import TransformerIndexBinding, TransformerIndexBindingUpdate
+
+if TYPE_CHECKING:
+    from lexy_py.client import LexyClient
 
 
 class BindingClient:
@@ -17,9 +20,10 @@ class BindingClient:
         client (httpx.Client): Synchronous API client.
     """
 
-    def __init__(self, aclient: httpx.AsyncClient, client: httpx.Client) -> None:
-        self.aclient = aclient
-        self.client = client
+    def __init__(self, lexy_client: "LexyClient") -> None:
+        self._lexy_client = lexy_client
+        self.aclient = self._lexy_client.aclient
+        self.client = self._lexy_client.client
 
     def list_bindings(self) -> list[TransformerIndexBinding]:
         """ Synchronously get a list of all bindings.
@@ -29,7 +33,7 @@ class BindingClient:
         """
         r = self.client.get("/bindings")
         handle_response(r)
-        return [TransformerIndexBinding(**binding) for binding in r.json()]
+        return [TransformerIndexBinding(**binding, client=self._lexy_client) for binding in r.json()]
 
     async def alist_bindings(self) -> list[TransformerIndexBinding]:
         """ Asynchronously get a list of all bindings.
@@ -39,7 +43,7 @@ class BindingClient:
         """
         r = await self.aclient.get("/bindings")
         handle_response(r)
-        return [TransformerIndexBinding(**binding) for binding in r.json()]
+        return [TransformerIndexBinding(**binding, client=self._lexy_client) for binding in r.json()]
 
     def add_binding(self, collection_id: str, transformer_id: str, index_id: str, description: Optional[str] = None,
                     execution_params: Optional[dict] = None, transformer_params: Optional[dict] = None,
@@ -77,7 +81,7 @@ class BindingClient:
         )
         r = self.client.post("/bindings", json=binding.dict(exclude_none=True))
         handle_response(r)
-        return TransformerIndexBinding(**r.json())
+        return TransformerIndexBinding(**r.json(), client=self._lexy_client)
 
     async def aadd_binding(self, collection_id: str, transformer_id: str, index_id: str,
                            description: Optional[str] = None, execution_params: Optional[dict] = None,
@@ -116,7 +120,7 @@ class BindingClient:
         )
         r = await self.aclient.post("/bindings", json=binding.dict(exclude_none=True))
         handle_response(r)
-        return TransformerIndexBinding(**r.json())
+        return TransformerIndexBinding(**r.json(), client=self._lexy_client)
 
     def get_binding(self, binding_id: int) -> TransformerIndexBinding:
         """ Synchronously get a binding.
@@ -129,7 +133,7 @@ class BindingClient:
         """
         r = self.client.get(f"/bindings/{binding_id}")
         handle_response(r)
-        return TransformerIndexBinding(**r.json())
+        return TransformerIndexBinding(**r.json(), client=self._lexy_client)
 
     async def aget_binding(self, binding_id: int) -> TransformerIndexBinding:
         """ Asynchronously get a binding.
@@ -142,7 +146,7 @@ class BindingClient:
         """
         r = await self.aclient.get(f"/bindings/{binding_id}")
         handle_response(r)
-        return TransformerIndexBinding(**r.json())
+        return TransformerIndexBinding(**r.json(), client=self._lexy_client)
 
     def update_binding(self, binding_id: int, description: Optional[str] = None,
                        execution_params: Optional[dict] = None, transformer_params: Optional[dict] = None,
@@ -169,7 +173,7 @@ class BindingClient:
         )
         r = self.client.patch(f"/bindings/{binding_id}", json=binding.dict(exclude_none=True))
         handle_response(r)
-        return TransformerIndexBinding(**r.json())
+        return TransformerIndexBinding(**r.json(), client=self._lexy_client)
 
     async def aupdate_binding(self, binding_id: int, description: Optional[str] = None,
                               execution_params: Optional[dict] = None, transformer_params: Optional[dict] = None,
@@ -196,7 +200,7 @@ class BindingClient:
         )
         r = await self.aclient.patch(f"/bindings/{binding_id}", json=binding.dict(exclude_none=True))
         handle_response(r)
-        return TransformerIndexBinding(**r.json())
+        return TransformerIndexBinding(**r.json(), client=self._lexy_client)
 
     def delete_binding(self, binding_id: int) -> dict:
         """ Synchronously delete a binding.

--- a/sdk-python/lexy_py/binding/models.py
+++ b/sdk-python/lexy_py/binding/models.py
@@ -1,12 +1,15 @@
 from datetime import datetime
 from enum import Enum
-from typing import Any, Optional
+from typing import Any, Optional, TYPE_CHECKING
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, PrivateAttr
 
-from lexy_py.collection.models import Collection
-from lexy_py.index.models import Index
-from lexy_py.transformer.models import Transformer
+from lexy_py.collection.models import CollectionModel, Collection
+from lexy_py.index.models import IndexModel, Index
+from lexy_py.transformer.models import TransformerModel, Transformer
+
+if TYPE_CHECKING:
+    from lexy_py.client import LexyClient
 
 
 class BindingStatus(str, Enum):
@@ -16,7 +19,7 @@ class BindingStatus(str, Enum):
     DETACHED = "detached"
 
 
-class TransformerIndexBinding(BaseModel):
+class TransformerIndexBindingModel(BaseModel):
     """ Transformer-index binding model """
 
     binding_id: Optional[int] = None
@@ -32,9 +35,9 @@ class TransformerIndexBinding(BaseModel):
     filters: Optional[dict] = Field(default={})
     status: Optional[BindingStatus] = Field(default=BindingStatus.PENDING)
 
-    collection: Optional[Collection] = None
-    transformer: Optional[Transformer] = None
-    index: Optional[Index] = None
+    collection: Optional[CollectionModel] = None
+    transformer: Optional[TransformerModel] = None
+    index: Optional[IndexModel] = None
 
     def __repr__(self):
         return f"<TransformerIndexBinding " \
@@ -47,9 +50,26 @@ class TransformerIndexBinding(BaseModel):
 
 class TransformerIndexBindingUpdate(BaseModel):
     """ Transformer-index binding update model """
-
     description: Optional[str] = None
     execution_params: Optional[dict[str, Any]] = None
     transformer_params: Optional[dict[str, Any]] = None
     filters: Optional[dict[str, Any]] = None
     status: Optional[BindingStatus] = None
+
+
+class TransformerIndexBinding(TransformerIndexBindingModel):
+    __doc__ = TransformerIndexBindingModel.__doc__
+    _client: Optional["LexyClient"] = PrivateAttr(default=None)
+
+    def __init__(self, **data: Any):
+        super().__init__(**data)
+        self._client = data.pop('client', None)
+        self.collection: Collection = Collection(**self.collection.dict(), client=self._client)
+        self.index: Index = Index(**self.index.dict(), client=self._client)
+        self.transformer: Transformer = Transformer(**self.transformer.dict(), client=self._client)
+
+    @property
+    def client(self) -> "LexyClient":
+        if not self._client:
+            raise ValueError("API client has not been set.")
+        return self._client

--- a/sdk-python/lexy_py/client.py
+++ b/sdk-python/lexy_py/client.py
@@ -38,11 +38,11 @@ class LexyClient:
         self.aclient = httpx.AsyncClient(base_url=self.base_url, timeout=API_TIMEOUT)
         self.client = httpx.Client(base_url=self.base_url, timeout=API_TIMEOUT)
 
-        self.binding = BindingClient(self.aclient, self.client)
-        self.collection = CollectionClient(self.aclient, self.client)
-        self.document = DocumentClient(self.aclient, self.client)
-        self.index = IndexClient(self.aclient, self.client)
-        self.transformer = TransformerClient(self.aclient, self.client)
+        self.binding = BindingClient(self)
+        self.collection = CollectionClient(self)
+        self.document = DocumentClient(self)
+        self.index = IndexClient(self)
+        self.transformer = TransformerClient(self)
 
     async def __aenter__(self) -> "LexyClient":
         """ Async context manager entry point. """

--- a/sdk-python/lexy_py/collection/client.py
+++ b/sdk-python/lexy_py/collection/client.py
@@ -1,11 +1,14 @@
 """ Client for interacting with the Collection API. """
 
-from typing import Optional
+from typing import Optional, TYPE_CHECKING
 
 import httpx
 
 from lexy_py.exceptions import handle_response
-from .models import Collection
+from .models import Collection, CollectionUpdate
+
+if TYPE_CHECKING:
+    from lexy_py.client import LexyClient
 
 
 class CollectionClient:
@@ -17,9 +20,10 @@ class CollectionClient:
         client (httpx.Client): Synchronous API client.
     """
 
-    def __init__(self, aclient: httpx.AsyncClient, client: httpx.Client) -> None:
-        self.aclient = aclient
-        self.client = client
+    def __init__(self, lexy_client: "LexyClient") -> None:
+        self._lexy_client = lexy_client
+        self.aclient = self._lexy_client.aclient
+        self.client = self._lexy_client.client
 
     def list_collections(self) -> list[Collection]:
         """ Synchronously get a list of all collections.
@@ -29,7 +33,7 @@ class CollectionClient:
         """
         r = self.client.get("/collections")
         handle_response(r)
-        return [Collection(**collection) for collection in r.json()]
+        return [Collection(**collection, client=self._lexy_client) for collection in r.json()]
 
     async def alist_collections(self) -> list[Collection]:
         """ Asynchronously get a list of all collections.
@@ -39,7 +43,7 @@ class CollectionClient:
         """
         r = await self.aclient.get("/collections")
         handle_response(r)
-        return [Collection(**collection) for collection in r.json()]
+        return [Collection(**collection, client=self._lexy_client) for collection in r.json()]
 
     def get_collection(self, collection_id: str) -> Collection:
         """ Synchronously get a collection.
@@ -52,7 +56,7 @@ class CollectionClient:
         """
         r = self.client.get(f"/collections/{collection_id}")
         handle_response(r)
-        return Collection(**r.json())
+        return Collection(**r.json(), client=self._lexy_client)
 
     async def aget_collection(self, collection_id: str) -> Collection:
         """ Asynchronously get a collection.
@@ -65,14 +69,14 @@ class CollectionClient:
         """
         r = await self.aclient.get(f"/collections/{collection_id}")
         handle_response(r)
-        return Collection(**r.json())
+        return Collection(**r.json(), client=self._lexy_client)
 
     def add_collection(self, collection_id: str, description: Optional[str] = None) -> Collection:
         """ Synchronously create a new collection.
 
         Args:
             collection_id (str): The ID of the collection to create.
-            description (Optional[str], optional): The description of the collection. Defaults to None.
+            description (str, optional): The description of the collection. Defaults to None.
 
         Returns:
             Collection: The created collection.
@@ -83,14 +87,14 @@ class CollectionClient:
         )
         r = self.client.post("/collections", json=collection.dict(exclude_none=True))
         handle_response(r)
-        return Collection(**r.json())
+        return Collection(**r.json(), client=self._lexy_client)
 
     async def aadd_collection(self, collection_id: str, description: Optional[str] = None) -> Collection:
         """ Asynchronously create a new collection.
 
         Args:
             collection_id (str): The ID of the collection to create.
-            description (Optional[str], optional): The description of the collection. Defaults to None.
+            description (str, optional): The description of the collection. Defaults to None.
 
         Returns:
             Collection: The created collection.
@@ -101,43 +105,41 @@ class CollectionClient:
         )
         r = await self.aclient.post("/collections", json=collection.dict(exclude_none=True))
         handle_response(r)
-        return Collection(**r.json())
+        return Collection(**r.json(), client=self._lexy_client)
 
     def update_collection(self, collection_id: str, description: Optional[str] = None) -> Collection:
         """ Synchronously update a collection.
 
         Args:
             collection_id (str): The ID of the collection to update.
-            description (Optional[str], optional): The description of the collection. Defaults to None.
+            description (str, optional): The updated description of the collection. Defaults to None.
 
         Returns:
             Collection: The updated collection.
         """
-        collection = Collection(
-            collection_id=collection_id,
+        collection = CollectionUpdate(
             description=description
         )
         r = self.client.patch(f"/collections/{collection_id}", json=collection.dict(exclude_none=True))
         handle_response(r)
-        return Collection(**r.json())
+        return Collection(**r.json(), client=self._lexy_client)
 
     async def aupdate_collection(self, collection_id: str, description: Optional[str] = None) -> Collection:
         """ Asynchronously update a collection.
 
         Args:
             collection_id (str): The ID of the collection to update.
-            description (Optional[str], optional): The description of the collection. Defaults to None.
+            description (str, optional): The updated description of the collection. Defaults to None.
 
         Returns:
             Collection: The updated collection.
         """
-        collection = Collection(
-            collection_id=collection_id,
+        collection = CollectionUpdate(
             description=description
         )
         r = await self.aclient.patch(f"/collections/{collection_id}", json=collection.dict(exclude_none=True))
         handle_response(r)
-        return Collection(**r.json())
+        return Collection(**r.json(), client=self._lexy_client)
 
     def delete_collection(self, collection_id: str) -> dict:
         """ Synchronously delete a collection.

--- a/sdk-python/lexy_py/collection/models.py
+++ b/sdk-python/lexy_py/collection/models.py
@@ -1,10 +1,15 @@
 from datetime import datetime
-from typing import Optional
+from typing import Any, Optional, TYPE_CHECKING
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, PrivateAttr
+
+from lexy_py.document.models import Document
+
+if TYPE_CHECKING:
+    from lexy_py.client import LexyClient
 
 
-class Collection(BaseModel):
+class CollectionModel(BaseModel):
     """ Collection model """
 
     collection_id: str = Field(
@@ -15,3 +20,35 @@ class Collection(BaseModel):
     description: Optional[str] = None
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None
+
+    def __repr__(self):
+        return f"<Collection('{self.collection_id}', description={self.description})>"
+
+
+class CollectionUpdate(BaseModel):
+    """ Collection update model """
+
+    description: Optional[str] = None
+
+
+class Collection(CollectionModel):
+    __doc__ = CollectionModel.__doc__
+    _client: Optional["LexyClient"] = PrivateAttr(default=None)
+
+    def __init__(self, **data: Any):
+        super().__init__(**data)
+        self._client = data.pop('client', None)
+
+    @property
+    def client(self) -> "LexyClient":
+        if not self._client:
+            raise ValueError("API client has not been set.")
+        return self._client
+
+    def list_documents(self) -> list[Document]:
+        """ Synchronously get all documents in the collection.
+
+        Returns:
+            list[Document]: A list of all documents in the collection.
+        """
+        return self.client.document.list_documents(self.collection_id)

--- a/sdk-python/lexy_py/document/models.py
+++ b/sdk-python/lexy_py/document/models.py
@@ -1,13 +1,15 @@
 import textwrap
 from datetime import datetime
-from typing import Any, Optional
+from typing import Any, Optional, TYPE_CHECKING
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, PrivateAttr
+
+if TYPE_CHECKING:
+    from lexy_py.client import LexyClient
 
 
-class Document(BaseModel):
+class DocumentModel(BaseModel):
     """ Document model """
-
     document_id: Optional[str] = None
     content: str = Field(..., min_length=1)
     meta: Optional[dict[Any, Any]] = Field(default={})
@@ -16,18 +18,34 @@ class Document(BaseModel):
     collection_id: Optional[str] = None
 
     def __repr__(self):
-        return f'<Document("{textwrap.shorten(self.content, 100, placeholder="...")}", document_id={self.document_id})>'
+        return f'<Document("{textwrap.shorten(self.content, 100, placeholder="...")}", {self.document_id})>'
+
+    def __init__(self, content: str, **data: Any):
+        super().__init__(content=content, **data)
 
 
 class DocumentCreate(BaseModel):
     """ Document create model """
-
     content: str = Field(..., min_length=1)
     meta: Optional[dict[Any, Any]] = Field(default={})
 
 
 class DocumentUpdate(BaseModel):
     """ Document update model """
-
     content: Optional[str] = None
     meta: Optional[dict[Any, Any]] = None
+
+
+class Document(DocumentModel):
+    __doc__ = DocumentModel.__doc__
+    _client: Optional["LexyClient"] = PrivateAttr(default=None)
+
+    def __init__(self, content: str, **data: Any):
+        super().__init__(content=content, **data)
+        self._client = data.pop('client', None)
+
+    @property
+    def client(self) -> "LexyClient":
+        if not self._client:
+            raise ValueError("API client has not been set.")
+        return self._client

--- a/sdk-python/lexy_py/index/models.py
+++ b/sdk-python/lexy_py/index/models.py
@@ -1,12 +1,14 @@
 from datetime import datetime
-from typing import Any, Optional
+from typing import Any, Optional, TYPE_CHECKING
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, PrivateAttr
+
+if TYPE_CHECKING:
+    from lexy_py.client import LexyClient
 
 
-class Index(BaseModel):
+class IndexModel(BaseModel):
     """ Index model """
-
     index_id: str = Field(..., min_length=1)
     description: Optional[str] = None
     index_table_schema: Optional[dict[str, Any]] = Field(default={})
@@ -15,10 +17,40 @@ class Index(BaseModel):
     updated_at: Optional[datetime] = None
     index_table_name: Optional[str] = None
 
+    def __repr__(self):
+        return f"<Index('{self.index_id}', description='{self.description}')>"
+
 
 class IndexUpdate(BaseModel):
     """ Index update model """
-
     description: Optional[str] = None
     index_table_schema: Optional[dict[str, Any]] = None
     index_fields: Optional[dict[str, Any]] = None
+
+
+class Index(IndexModel):
+    __doc__ = IndexModel.__doc__
+    _client: Optional["LexyClient"] = PrivateAttr(default=None)
+
+    def __init__(self, **data: Any):
+        super().__init__(**data)
+        self._client = data.pop('client', None)
+
+    @property
+    def client(self) -> "LexyClient":
+        if not self._client:
+            raise ValueError("API client has not been set.")
+        return self._client
+
+    def query(self, query_string: str, query_field: str = "embedding", k: int = 5) -> list[dict]:
+        """ Synchronously query an index.
+
+        Args:
+            query_string (str): The query string.
+            query_field (str, optional): The field to query. Defaults to "embedding".
+            k (int, optional): The number of records to return. Defaults to 5.
+
+        Returns:
+            list[dict]: The query results.
+        """
+        return self.client.index.query_index(query_string, self.index_id, query_field, k)

--- a/sdk-python/lexy_py/transformer/models.py
+++ b/sdk-python/lexy_py/transformer/models.py
@@ -1,19 +1,40 @@
 from datetime import datetime
-from typing import Optional
+from typing import Any, Optional, TYPE_CHECKING
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, PrivateAttr
+
+if TYPE_CHECKING:
+    from lexy_py.client import LexyClient
 
 
-class Transformer(BaseModel):
+class TransformerModel(BaseModel):
     """ Transformer model """
-
     transformer_id: str = Field(..., min_length=1, max_length=255, regex=r"^[a-zA-Z][a-zA-Z0-9_.]+$")
     path: Optional[str] = Field(..., min_length=1, max_length=255, regex=r"^[a-zA-Z][a-zA-Z0-9_.]+$")
     description: Optional[str] = None
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None
 
+    def __repr__(self):
+        return f"<Transformer('{self.transformer_id}', description='{self.description}')>"
+
 
 class TransformerUpdate(BaseModel):
+    """ Transformer update model """
     path: Optional[str] = None
     description: Optional[str] = None
+
+
+class Transformer(TransformerModel):
+    __doc__ = TransformerModel.__doc__
+    _client: Optional["LexyClient"] = PrivateAttr(default=None)
+
+    def __init__(self, **data: Any):
+        super().__init__(**data)
+        self._client = data.pop('client', None)
+
+    @property
+    def client(self) -> "LexyClient":
+        if not self._client:
+            raise ValueError("API client has not been set.")
+        return self._client

--- a/sdk-python/lexy_py_tests/test_binding.py
+++ b/sdk-python/lexy_py_tests/test_binding.py
@@ -1,6 +1,9 @@
 import pytest
 
 from lexy_py.client import LexyClient
+from lexy_py.collection.models import Collection
+from lexy_py.index.models import Index
+from lexy_py.transformer.models import Transformer
 
 
 lexy = LexyClient()
@@ -25,3 +28,38 @@ class TestBindingClient:
     async def test_alist_bindings(self):
         bindings = await lexy.binding.alist_bindings()
         assert len(bindings) > 0
+
+    def test_get_binding(self):
+        binding = lexy.binding.get_binding(binding_id=1)
+        assert binding.binding_id == 1
+        assert isinstance(binding.client, LexyClient)
+
+        assert isinstance(binding.collection, Collection)
+        assert binding.collection.collection_id == "default"
+        assert isinstance(binding.collection.client, LexyClient)
+
+        assert isinstance(binding.index, Index)
+        assert binding.index.index_id == "default_text_embeddings"
+        assert isinstance(binding.index.client, LexyClient)
+
+        assert isinstance(binding.transformer, Transformer)
+        assert binding.transformer.transformer_id == "text.embeddings.minilm"
+        assert isinstance(binding.transformer.client, LexyClient)
+
+    @pytest.mark.asyncio
+    async def test_aget_binding(self):
+        binding = await lexy.binding.aget_binding(binding_id=1)
+        assert binding.binding_id == 1
+        assert isinstance(binding.client, LexyClient)
+
+        assert isinstance(binding.collection, Collection)
+        assert binding.collection.collection_id == "default"
+        assert isinstance(binding.collection.client, LexyClient)
+
+        assert isinstance(binding.index, Index)
+        assert binding.index.index_id == "default_text_embeddings"
+        assert isinstance(binding.index.client, LexyClient)
+
+        assert isinstance(binding.transformer, Transformer)
+        assert binding.transformer.transformer_id == "text.embeddings.minilm"
+        assert isinstance(binding.transformer.client, LexyClient)

--- a/sdk-python/lexy_py_tests/test_collection.py
+++ b/sdk-python/lexy_py_tests/test_collection.py
@@ -1,6 +1,7 @@
 import pytest
 
 from lexy_py.client import LexyClient
+from lexy_py.collection.models import Collection
 
 
 lexy = LexyClient()
@@ -42,18 +43,29 @@ class TestCollectionClient:
         collections = lexy.collection.list_collections()
         assert len(collections) > 0
         assert collections[0].collection_id == "default"
+        assert isinstance(collections[0].client, LexyClient)
 
     @pytest.mark.asyncio
     async def test_alist_collections(self):
         collections = await lexy.collection.alist_collections()
         assert len(collections) > 0
         assert collections[0].collection_id == "default"
+        assert isinstance(collections[0].client, LexyClient)
 
     def test_get_collection(self):
         collection = lexy.collection.get_collection("default")
         assert collection.collection_id == "default"
+        assert isinstance(collection.client, LexyClient)
 
     @pytest.mark.asyncio
     async def test_aget_collection(self):
         collection = await lexy.collection.aget_collection("default")
         assert collection.collection_id == "default"
+        assert isinstance(collection.client, LexyClient)
+
+    def test_collection_client(self):
+        collection_without_a_client = Collection(collection_id="no_client", description="No client")
+        with pytest.raises(ValueError) as exc_info:
+            collection_without_a_client.list_documents()
+        assert isinstance(exc_info.value, ValueError)
+        assert str(exc_info.value) == "API client has not been set."

--- a/sdk-python/lexy_py_tests/test_index.py
+++ b/sdk-python/lexy_py_tests/test_index.py
@@ -50,10 +50,10 @@ class TestIndexClient:
         assert len(indexes) > 0
 
     def test_query_index(self):
-        results = lexy.index.query_index("default_text_embeddings", "Test Query", k=5)
+        results = lexy.index.query_index("Test Query", "default_text_embeddings", k=5)
         assert len(results) > 0
 
     @pytest.mark.asyncio
     async def test_aquery_index(self):
-        results = await lexy.index.aquery_index("default_text_embeddings", "Test Query", k=5)
+        results = await lexy.index.aquery_index("Test Query", "default_text_embeddings", k=5)
         assert len(results) > 0


### PR DESCRIPTION
# What

This PR updates the Python SDK.

- Instances of models now have an optional client property for making model specific requests.
  - For example, `collection.list_documents()` will list documents in a specific collection.
- Related model objects are now created for binding instances.
  - For example, `binding.collection` returns a `Collection` object.
- Updated signature for `Document` objects.
  - A document can now be created with `content` as its only argument, e.g. `Document("this is my content")`. 
- Updated tests.
  - Also added a Jupyter notebook (`tests.ipynb`) with tests for easier development.

# Why

Python SDK is now easier to use for development. 

# Test plan

```bash
pytest sdk-python
```
