### PR TITLE
Improvements to document logic

### DIFF
--- a/examples/tests.ipynb
+++ b/examples/tests.ipynb
@@ -376,21 +376,10 @@
    "execution_count": null,
    "outputs": [],
    "source": [
-    "new_doc_response = lexy.document.add_documents([\n",
+    "new_docs = lexy.document.add_documents([\n",
     "    {'content': 'This is my shiny new document!'}\n",
     "])\n",
-    "new_doc_response"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "outputs": [],
-   "source": [
-    "new_doc = Document(**new_doc_response[0]['document'], client=lexy)\n",
+    "new_doc = new_docs[0]\n",
     "new_doc"
    ],
    "metadata": {

--- a/sdk-python/lexy_py/document/client.py
+++ b/sdk-python/lexy_py/document/client.py
@@ -51,9 +51,8 @@ class DocumentClient:
         handle_response(r)
         return [Document(**document, client=self._lexy_client) for document in r.json()]
 
-    # TODO: fix the return type here
     def add_documents(self, docs: Document | list[Document] | dict | list[dict],
-                      collection_id: str = "default") -> list[dict]:
+                      collection_id: str = "default") -> list[Document]:
         """ Synchronously add documents to a collection.
 
         Args:
@@ -61,16 +60,16 @@ class DocumentClient:
             collection_id (str): The ID of the collection to add the documents to. Defaults to "default".
 
         Returns:
-            list[dict]: A list of dictionaries containing created documents and their associated tasks.
+            list[Document]: A list of created documents.
         """
         processed_docs = self._process_docs(docs)
 
         r = self.client.post("/documents", json=processed_docs, params={"collection_id": collection_id})
         handle_response(r)
-        return r.json()
+        return [Document(**document['document'], client=self._lexy_client) for document in r.json()]
 
     async def aadd_documents(self, docs: Document | list[Document] | dict | list[dict],
-                             collection_id: str = "default") -> list[dict]:
+                             collection_id: str = "default") -> list[Document]:
         """ Asynchronously add documents to a collection.
 
         Args:
@@ -78,15 +77,15 @@ class DocumentClient:
             collection_id (str): The ID of the collection to add the documents to. Defaults to "default".
 
         Returns:
-            list[dict]: A list of dictionaries containing created documents and their associated tasks.
+            list[Document]: A list of created documents.
         """
         processed_docs = self._process_docs(docs)
 
         r = await self.aclient.post("/documents", json=processed_docs, params={"collection_id": collection_id})
         handle_response(r)
-        return r.json()
+        return [Document(**document['document'], client=self._lexy_client) for document in r.json()]
 
-    def add_document(self, doc: Document | dict, collection_id: str) -> dict:
+    def add_document(self, doc: Document | dict, collection_id: str) -> Document:
         """ Synchronously add a document to a collection.
 
         Args:
@@ -94,15 +93,15 @@ class DocumentClient:
             collection_id (str): The ID of the collection to add the document to.
 
         Returns:
-            dict: A dictionary containing the created document and its associated tasks.
+            Document: The created document.
         """
         processed_docs = self._process_docs(doc)
 
         r = self.client.post("/documents", json=processed_docs, params={"collection_id": collection_id})
         handle_response(r)
-        return r.json()[0]
+        return Document(**r.json()[0]['document'], client=self._lexy_client)
 
-    async def aadd_document(self, doc: Document | dict, collection_id: str) -> dict:
+    async def aadd_document(self, doc: Document | dict, collection_id: str) -> Document:
         """ Asynchronously add a document to a collection.
 
         Args:
@@ -110,13 +109,13 @@ class DocumentClient:
             collection_id (str): The ID of the collection to add the document to.
 
         Returns:
-            dict: A dictionary containing the created document and its associated tasks.
+            Document: The created document.
         """
         processed_docs = self._process_docs(doc)
 
         r = await self.aclient.post("/documents", json=processed_docs, params={"collection_id": collection_id})
         handle_response(r)
-        return r.json()[0]
+        return Document(**r.json()[0]['document'], client=self._lexy_client)
 
     def get_document(self, document_id: str) -> Document:
         """ Synchronously get a document.
@@ -144,7 +143,7 @@ class DocumentClient:
         handle_response(r)
         return Document(**r.json(), client=self._lexy_client)
 
-    def update_document(self, document_id: str, content: Optional[str] = None, meta: Optional[dict] = None) -> dict:
+    def update_document(self, document_id: str, content: Optional[str] = None, meta: Optional[dict] = None) -> Document:
         """ Synchronously update a document.
 
         Args:
@@ -153,15 +152,15 @@ class DocumentClient:
             meta (dict, optional): The new metadata for the document.
 
         Returns:
-            dict: A dictionary containing the updated document and its associated tasks.
+            Document: The updated document.
         """
         document = DocumentUpdate(content=content, meta=meta)
         r = self.client.patch(f"/documents/{document_id}", json=document.dict(exclude_none=True))
         handle_response(r)
-        return r.json()
+        return Document(**r.json()['document'], client=self._lexy_client)
 
     async def aupdate_document(self, document_id: str, content: Optional[str] = None,
-                               meta: Optional[dict] = None) -> dict:
+                               meta: Optional[dict] = None) -> Document:
         """ Asynchronously update a document.
 
         Args:
@@ -170,12 +169,12 @@ class DocumentClient:
             meta (dict, optional): The new metadata for the document.
 
         Returns:
-            dict: A dictionary containing the updated document and its associated tasks.
+            Document: The updated document.
         """
         document = DocumentUpdate(content=content, meta=meta)
         r = await self.aclient.patch(f"/documents/{document_id}", json=document.dict(exclude_none=True))
         handle_response(r)
-        return r.json()
+        return Document(**r.json()['document'], client=self._lexy_client)
 
     def delete_document(self, document_id: str) -> dict:
         """ Synchronously delete a document.

--- a/sdk-python/lexy_py_tests/test_document.py
+++ b/sdk-python/lexy_py_tests/test_document.py
@@ -28,15 +28,15 @@ class TestDocumentClient:
             {"content": "Test Document 2 Content"}
         ], collection_id="tmp_collection")
         assert len(docs_added) == 2
-        assert docs_added[0]["document"]["content"] == "Test Document 1 Content"
-        assert docs_added[1]["document"]["content"] == "Test Document 2 Content"
-        assert docs_added[0]["document"]["document_id"] is not None
-        assert docs_added[0]["document"]["created_at"] is not None
-        assert docs_added[0]["document"]["collection_id"] == "tmp_collection"
+        assert docs_added[0].content == "Test Document 1 Content"
+        assert docs_added[1].content == "Test Document 2 Content"
+        assert docs_added[0].document_id is not None
+        assert docs_added[0].created_at is not None
+        assert docs_added[0].collection_id == "tmp_collection"
 
         # get test document
-        test_document = lexy.document.get_document(docs_added[0]["document"]["document_id"])
-        assert test_document.document_id == docs_added[0]["document"]["document_id"]
+        test_document = lexy.document.get_document(docs_added[0].document_id)
+        assert test_document.document_id == docs_added[0].document_id
         assert test_document.content == "Test Document 1 Content"
 
         # update test document
@@ -44,7 +44,7 @@ class TestDocumentClient:
             document_id=test_document.document_id,
             content="Test Document 1 Updated Content"
         )
-        updated_document = lexy.document.get_document(doc_updated["document"]["document_id"])
+        updated_document = lexy.document.get_document(doc_updated.document_id)
         assert updated_document.document_id == test_document.document_id
         assert updated_document.content == "Test Document 1 Updated Content"
         assert updated_document.updated_at > updated_document.created_at
@@ -54,7 +54,7 @@ class TestDocumentClient:
         assert response == {"Say": "Document deleted!"}
 
         # delete remaining test documents
-        response = lexy.document.delete_document(document_id=docs_added[1]["document"]["document_id"])
+        response = lexy.document.delete_document(document_id=docs_added[1].document_id)
         assert response == {"Say": "Document deleted!"}
 
         # verify that there are no documents in the test collection


### PR DESCRIPTION
# What

- The task `save_records_to_index` now issues a `session.rollback()` following an exception triggered by `session.commit()`.
  - This prevents subsequent instances of `PendingRollbackError`.
- The Python client now returns type `Document` instead of dictionaries with documents and their associated tasks.

# Why

- The database tasks are now more resilient in case of race conditions.
- It's more intuitive for `add_documents` to return `Document` objects, and those objects will have instances of `LexyClient` assigned.


# Test plan

Adding a document and deleting it immediately raises a foreign key violation. 


```python
>>> rolling_stone = lexy.document.add_documents([
...     {'content': 'Dear doc, we barely knew ya.'}
... ])
>>> rolling_stone
# [<Document("Dear doc, we barely knew ya.", 38298981-be72-40b5-94f1-2b02eb7512c9)>]
>>> lexy.document.delete_document(rolling_stone[0].document_id)
# {'Say': 'Document deleted!'}
```

Then, subsequent documents added wouldn't be saved to the index because they would encounter a `PendingRollbackError`. Following this PR, the subsequent errors no longer occur. 

```python
here_to_stay = lexy.document.add_documents([
    {'content': 'were not going anywhere'},
    {'content': 'were here to stay'}
])
```
