### PR TITLE
Getting Started notebook and Python client improvements.

### DIFF
--- a/examples/getting_started.ipynb
+++ b/examples/getting_started.ipynb
@@ -1,0 +1,483 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
+   "source": [
+    "# Getting started"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
+   "source": [
+    "## Quickstart"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from lexy_py import LexyClient\n",
+    "\n",
+    "lexy = LexyClient()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
+   "source": [
+    "We can get more information about the Lexy instance by calling the `info` method. Here we see existing Collections, Indexes, Transformers, and Bindings."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "lexy.info()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
+   "source": [
+    "There are several documents already in the \"**default**\" collection. We can list them with the `list_documents` method."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "lexy.list_documents()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
+   "source": [
+    "The documents in the \"**default**\" collection are automatically embedded, and the embeddings are stored in the index \"**default_text_embeddings**\"."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "lexy.indexes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
+   "source": [
+    "We can query the index for \"_what is deep learning_\" and see our documents ranked by cosine similarity."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "lexy.query_index('what is deep learning')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
+   "source": [
+    "## Extended example: Famous biographies\n",
+    "\n",
+    "Let's go through a longer example to see how we can use Lexy to create and query embeddings for a new collection of documents."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Collections and Documents\n",
+    "\n",
+    "We can see that there are currently two collections, \"**default**\" and \"**code**\". Let's create a new collection for famous biographies."
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "lexy.collections"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "bios = lexy.create_collection('bios', description='Famous biographies')\n",
+    "bios"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
+   "source": [
+    "We can see that our new collection is now listed in the `collections` property, and that it contains no documents."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "lexy.collections"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "bios.list_documents()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
+   "source": [
+    "Let's add a few documents to our new collection."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "bios.add_documents([\n",
+    "    {\"content\": \"Stephen Curry is an American professional basketball player for the Golden State Warriors.\"},\n",
+    "    {\"content\": \"Dwayne 'The Rock' Johnson is a well-known actor, former professional wrestler, and businessman.\"},\n",
+    "    {\"content\": \"Taylor Swift is a singer known for her songwriting, musical versatility, and artistic reinventions.\"}\n",
+    "])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
+   "source": [
+    "### Indexes and Bindings\n",
+    "\n",
+    "Now we want to create embeddings for the documents in our new collection. We'll use the \"**text.embeddings.minilm**\" transformer, which uses the [MiniLM sentence transformer](https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2) model to generate embeddings for text."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "lexy.transformers"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
+   "source": [
+    "Before we can bind this transformer to our collection, we need to create an index for storing the resulting embeddings. Let's create a new index called \"**bios_index**\" with embeddings for our new collection. Our index will have a single field called \"**bio_embedding**\" that will store the embeddings output by the MiniLM sentence transformer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "index_fields = {\n",
+    "    \"bio_embedding\": {\"type\": \"embedding\", \"extras\": {\"dims\": 384, \"distance\": \"cosine\"}}\n",
+    "}\n",
+    "index = lexy.create_index(index_id='bios_index', description='Biography embeddings', index_fields=index_fields)\n",
+    "index"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "lexy.indexes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
+   "source": [
+    "Now let's create a new binding. Our binding will feed the documents in our \"**bios**\" collection into the \"**text.embeddings.minilm**\" transformer, and insert the resulting output in our newly created index, \"**bios_index**\".\n",
+    "<br>\n",
+    "<h5><center>`bios` Collection &nbsp;&nbsp;&rarr;&nbsp;&nbsp; `text.embeddings.minilm` Transformer &nbsp;&nbsp;&rarr;&nbsp;&nbsp; `bios_index` Index </center></h5>\n",
+    "<br>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "binding = lexy.create_binding(collection_id='bios', index_id='bios_index', transformer_id='text.embeddings.minilm')\n",
+    "binding"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
+   "source": [
+    "Our binding automatically runs asynchronous jobs to process our documents and store the results in our index as embeddings. We can now query our index for \"_famous artists_\" and see the results ranked by cosine similarity."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "index.query('famous artists', query_field='bio_embedding', k=3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
+   "source": [
+    "Because our binding has status set to \"`ON`\", any new documents added to our collection will automatically be processed by our transformer and inserted into our index. We can add another document, and then run the same query to see the new results."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "bios.add_documents([\n",
+    "    {\"content\": \"Beyoncé is a singer and songwriter recognized for her boundary-pushing artistry, vocals, and performances.\"}\n",
+    "])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "index.query('famous artists', query_field='bio_embedding', k=3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Transformers\n",
+    "\n",
+    "So far, we've only used the default transformers included in Lexy. Let's see how we can easily create our own transformers."
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "_Coming soon._"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/tests.ipynb
+++ b/examples/tests.ipynb
@@ -14,7 +14,7 @@
    "execution_count": null,
    "outputs": [],
    "source": [
-    "from lexy_py.client import LexyClient\n",
+    "from lexy_py import LexyClient\n",
     "\n",
     "lexy = LexyClient()"
    ],
@@ -57,7 +57,7 @@
    "execution_count": null,
    "outputs": [],
    "source": [
-    "lexy.collection.list_collections()"
+    "lexy.list_collections()"
    ],
    "metadata": {
     "collapsed": false
@@ -77,7 +77,7 @@
    "execution_count": null,
    "outputs": [],
    "source": [
-    "default_collection = lexy.collection.get_collection('default')\n",
+    "default_collection = lexy.get_collection('default')\n",
     "default_collection"
    ],
    "metadata": {
@@ -171,7 +171,7 @@
    "execution_count": null,
    "outputs": [],
    "source": [
-    "new_collection = lexy.collection.add_collection(collection_id='junk', description='just testing for now')\n",
+    "new_collection = lexy.create_collection(collection_id='junk', description='just testing for now')\n",
     "new_collection"
    ],
    "metadata": {
@@ -183,7 +183,7 @@
    "execution_count": null,
    "outputs": [],
    "source": [
-    "lexy.collection.list_collections()"
+    "lexy.list_collections()"
    ],
    "metadata": {
     "collapsed": false
@@ -205,7 +205,7 @@
    "execution_count": null,
    "outputs": [],
    "source": [
-    "lexy.collection.delete_collection('junk')"
+    "lexy.delete_collection('junk')"
    ],
    "metadata": {
     "collapsed": false
@@ -216,7 +216,7 @@
    "execution_count": null,
    "outputs": [],
    "source": [
-    "lexy.collection.list_collections()"
+    "lexy.list_collections()"
    ],
    "metadata": {
     "collapsed": false
@@ -245,7 +245,7 @@
    "execution_count": null,
    "outputs": [],
    "source": [
-    "lexy.document.list_documents()[:5]"
+    "lexy.list_documents()[:5]"
    ],
    "metadata": {
     "collapsed": false
@@ -256,7 +256,7 @@
    "execution_count": null,
    "outputs": [],
    "source": [
-    "code_docs = lexy.document.list_documents('code')\n",
+    "code_docs = lexy.list_documents('code')\n",
     "code_docs"
    ],
    "metadata": {
@@ -300,7 +300,7 @@
    "execution_count": null,
    "outputs": [],
    "source": [
-    "sample_doc = lexy.document.get_document('20984c80-2a3c-475d-af59-45864762fc73')\n",
+    "sample_doc = lexy.get_document(code_doc.document_id)\n",
     "sample_doc"
    ],
    "metadata": {
@@ -376,7 +376,7 @@
    "execution_count": null,
    "outputs": [],
    "source": [
-    "new_docs = lexy.document.add_documents([\n",
+    "new_docs = lexy.add_documents([\n",
     "    {'content': 'This is my shiny new document!'}\n",
     "])\n",
     "new_doc = new_docs[0]\n",
@@ -391,7 +391,7 @@
    "execution_count": null,
    "outputs": [],
    "source": [
-    "lexy.document.delete_document(document_id=new_doc.document_id)"
+    "lexy.delete_document(document_id=new_doc.document_id)"
    ],
    "metadata": {
     "collapsed": false
@@ -420,7 +420,7 @@
    "execution_count": null,
    "outputs": [],
    "source": [
-    "lexy.index.list_indexes()"
+    "lexy.list_indexes()"
    ],
    "metadata": {
     "collapsed": false
@@ -440,7 +440,7 @@
    "execution_count": null,
    "outputs": [],
    "source": [
-    "idx = lexy.index.get_index('default_text_embeddings')\n",
+    "idx = lexy.get_index('default_text_embeddings')\n",
     "idx"
    ],
    "metadata": {
@@ -523,7 +523,7 @@
    "execution_count": null,
    "outputs": [],
    "source": [
-    "lexy.binding.list_bindings()"
+    "lexy.list_bindings()"
    ],
    "metadata": {
     "collapsed": false
@@ -543,7 +543,7 @@
    "execution_count": null,
    "outputs": [],
    "source": [
-    "binding = lexy.binding.get_binding(1)\n",
+    "binding = lexy.get_binding(1)\n",
     "binding"
    ],
    "metadata": {
@@ -652,7 +652,7 @@
    "execution_count": null,
    "outputs": [],
    "source": [
-    "from lexy_py.binding.models import TransformerIndexBinding"
+    "from lexy_py.binding.models import TransformerIndexBindingCreate"
    ],
    "metadata": {
     "collapsed": false
@@ -663,7 +663,7 @@
    "execution_count": null,
    "outputs": [],
    "source": [
-    "print(inspect.signature(TransformerIndexBinding))"
+    "print(inspect.signature(TransformerIndexBindingCreate))"
    ],
    "metadata": {
     "collapsed": false

--- a/lexy/api/endpoints/bindings.py
+++ b/lexy/api/endpoints/bindings.py
@@ -27,10 +27,12 @@ async def get_bindings(session: AsyncSession = Depends(get_session)) -> list[Tra
 
 
 @router.post("/bindings",
+             response_model=dict[str, TransformerIndexBindingRead | list[dict]],
              status_code=status.HTTP_201_CREATED,
              name="add_binding",
              description="Create a new binding")
-async def add_binding(binding: TransformerIndexBindingCreate, session: AsyncSession = Depends(get_session)) -> dict:
+async def add_binding(binding: TransformerIndexBindingCreate, session: AsyncSession = Depends(get_session)) \
+        -> dict[str, TransformerIndexBindingRead | list[dict]]:
     binding = TransformerIndexBinding(**binding.dict())
     session.add(binding)
     await session.commit()

--- a/lexy/db/init_db.py
+++ b/lexy/db/init_db.py
@@ -34,7 +34,6 @@ def add_sample_data_to_db(session=db):
         session.add(models.Document(**sample_data["document_3"]))
         session.add(models.Document(**sample_data["document_4"]))
         session.add(models.Document(**sample_data["document_5"]))
-        session.add(models.Document(**sample_data["document_6"]))
         session.commit()
     if session.query(models.Transformer).count() > 0:
         logger.info("Transformer data already exists")

--- a/lexy/db/sample_data.py
+++ b/lexy/db/sample_data.py
@@ -12,21 +12,17 @@ sample_data = {
         "collection_id": "default"
     },
     "document_2": {
-        "content": "Meh. This one is just ok.",
-        "collection_id": "default"
-    },
-    "document_3": {
         "content": "Starlink is a satellite internet constellation operated by American aerospace company SpaceX, "
                    "providing coverage to over 60 countries.",
         "collection_id": "default"
     },
-    "document_4": {
+    "document_3": {
         "content": "A latent space, also known as a latent feature space or embedding space, is an embedding of a set "
                    "of items within a manifold in which items resembling each other are positioned closer to one "
                    "another.",
         "collection_id": "default"
     },
-    "document_5": {
+    "document_4": {
         "content": "import this",
         "collection_id": "code",
         "meta": {
@@ -35,7 +31,7 @@ sample_data = {
             "language": "python"
         }
     },
-    "document_6": {
+    "document_5": {
         "content": "def multiply(a, b):"
                    "    return a * b"
                    ""
@@ -52,7 +48,7 @@ sample_data = {
     "transformer_1": {
         "transformer_id": "text.embeddings.minilm",
         "path": "lexy.transformers.embeddings.text_embeddings",
-        "description": "Text embeddings using Hugging Face model 'sentence-transformers/all-MiniLM-L6-v2'"
+        "description": "Text embeddings using \"sentence-transformers/all-MiniLM-L6-v2\""
     },
     "transformer_2": {
         "transformer_id": "text.counter.word_counter",

--- a/lexy/db/seed.py
+++ b/lexy/db/seed.py
@@ -17,7 +17,6 @@ async def add_sample_data_to_db(session: AsyncSession):
     session.add(Document(**sample_data["document_3"]))
     session.add(Document(**sample_data["document_4"]))
     session.add(Document(**sample_data["document_5"]))
-    session.add(Document(**sample_data["document_6"]))
     await session.commit()
     session.add(Transformer(**sample_data["transformer_1"]))
     session.add(Transformer(**sample_data["transformer_2"]))

--- a/lexy/models/binding.py
+++ b/lexy/models/binding.py
@@ -48,12 +48,12 @@ class TransformerIndexBinding(TransformerIndexBindingBase, table=True):
     index: Index = Relationship(back_populates="transformer_bindings", sa_relationship_kwargs={'lazy': 'selectin'})
 
     def __repr__(self):
-        return f"<TransformerIndexBinding " \
+        return f"<Binding(" \
                f"id={self.binding_id}, " \
                f"status={self.status}, " \
-               f"collection_id={self.collection_id}, " \
-               f"transformer_id={self.transformer_id}, " \
-               f"index_id={self.index_id}>"
+               f"collection='{self.collection_id}', " \
+               f"transformer='{self.transformer_id}', " \
+               f"index='{self.index_id}')>"
 
 
 class TransformerIndexBindingCreate(TransformerIndexBindingBase):

--- a/sdk-python/README.md
+++ b/sdk-python/README.md
@@ -7,7 +7,7 @@ This is the Python SDK for Lexy.
 ### Initiate client
 
 ```python
-from lexy_py.client import LexyClient
+from lexy_py import LexyClient
 
 lexy = LexyClient()
 ```
@@ -15,7 +15,7 @@ lexy = LexyClient()
 ### Add documents
 
 ```python
-lexy.document.add_documents([
+lexy.add_documents([
     {"content": "This is a test document"},
     {"content": "This is another one!"},
 ])
@@ -24,7 +24,7 @@ lexy.document.add_documents([
 ### Query index
 
 ```python
-lexy.index.query_index("test query", "default_text_embeddings", k=5)
+lexy.query_index("test query", "default_text_embeddings", k=5)
 ```
 
 ## Testing

--- a/sdk-python/lexy_py/__init__.py
+++ b/sdk-python/lexy_py/__init__.py
@@ -1,0 +1,3 @@
+""" Lexy Python SDK """
+
+from lexy_py.client import LexyClient

--- a/sdk-python/lexy_py/binding/client.py
+++ b/sdk-python/lexy_py/binding/client.py
@@ -5,7 +5,7 @@ from typing import Optional, TYPE_CHECKING
 import httpx
 
 from lexy_py.exceptions import handle_response
-from .models import TransformerIndexBinding, TransformerIndexBindingUpdate
+from .models import TransformerIndexBinding, TransformerIndexBindingCreate, TransformerIndexBindingUpdate
 
 if TYPE_CHECKING:
     from lexy_py.client import LexyClient
@@ -69,7 +69,7 @@ class BindingClient:
             transformer_params = {}
         if filters is None:
             filters = {}
-        binding = TransformerIndexBinding(
+        binding = TransformerIndexBindingCreate(
             collection_id=collection_id,
             transformer_id=transformer_id,
             index_id=index_id,
@@ -81,7 +81,7 @@ class BindingClient:
         )
         r = self.client.post("/bindings", json=binding.dict(exclude_none=True))
         handle_response(r)
-        return TransformerIndexBinding(**r.json(), client=self._lexy_client)
+        return TransformerIndexBinding(**r.json()["binding"], client=self._lexy_client)
 
     async def aadd_binding(self, collection_id: str, transformer_id: str, index_id: str,
                            description: Optional[str] = None, execution_params: Optional[dict] = None,
@@ -108,7 +108,7 @@ class BindingClient:
             transformer_params = {}
         if filters is None:
             filters = {}
-        binding = TransformerIndexBinding(
+        binding = TransformerIndexBindingCreate(
             collection_id=collection_id,
             transformer_id=transformer_id,
             index_id=index_id,
@@ -120,7 +120,7 @@ class BindingClient:
         )
         r = await self.aclient.post("/bindings", json=binding.dict(exclude_none=True))
         handle_response(r)
-        return TransformerIndexBinding(**r.json(), client=self._lexy_client)
+        return TransformerIndexBinding(**r.json()["binding"], client=self._lexy_client)
 
     def get_binding(self, binding_id: int) -> TransformerIndexBinding:
         """ Synchronously get a binding.

--- a/sdk-python/lexy_py/binding/models.py
+++ b/sdk-python/lexy_py/binding/models.py
@@ -40,12 +40,24 @@ class TransformerIndexBindingModel(BaseModel):
     index: Optional[IndexModel] = None
 
     def __repr__(self):
-        return f"<TransformerIndexBinding " \
+        return f"<Binding(" \
                f"id={self.binding_id}, " \
                f"status={self.status.name}, " \
-               f"collection_id={self.collection_id}, " \
-               f"transformer_id={self.transformer_id}, " \
-               f"index_id={self.index_id}>"
+               f"collection='{self.collection_id}', " \
+               f"transformer='{self.transformer_id}', " \
+               f"index='{self.index_id}')>"
+
+
+class TransformerIndexBindingCreate(BaseModel):
+    """ Transformer-index binding create model """
+    collection_id: str
+    transformer_id: str
+    index_id: str
+    description: Optional[str] = None
+    execution_params: Optional[dict[str, Any]] = Field(default={})
+    transformer_params: Optional[dict[str, Any]] = Field(default={})
+    filters: Optional[dict[str, Any]] = Field(default={})
+    status: Optional[BindingStatus] = Field(default=BindingStatus.PENDING)
 
 
 class TransformerIndexBindingUpdate(BaseModel):

--- a/sdk-python/lexy_py/client.py
+++ b/sdk-python/lexy_py/client.py
@@ -21,6 +21,11 @@ class LexyClient:
         base_url (str): Base URL for the Lexy API.
         aclient (httpx.AsyncClient): Asynchronous API client.
         client (httpx.Client): Synchronous API client.
+        binding (BindingClient): Client for interacting with the Bindings API.
+        collection (CollectionClient): Client for interacting with the Collections API.
+        document (DocumentClient): Client for interacting with the Documents API.
+        index (IndexClient): Client for interacting with the Indexes API.
+        transformer (TransformerClient): Client for interacting with the Transformers API.
     """
 
     base_url: str
@@ -34,15 +39,55 @@ class LexyClient:
     transformer: TransformerClient
 
     def __init__(self, base_url: str = DEFAULT_BASE_URL) -> None:
+        """ Initialize a LexyClient instance.
+
+        Args:
+            base_url (str, optional): Base URL for the Lexy API. Defaults to DEFAULT_BASE_URL.
+        """
         self.base_url = base_url
         self.aclient = httpx.AsyncClient(base_url=self.base_url, timeout=API_TIMEOUT)
         self.client = httpx.Client(base_url=self.base_url, timeout=API_TIMEOUT)
 
+        # binding
         self.binding = BindingClient(self)
+        self.create_binding = self.binding.add_binding
+        self.delete_binding = self.binding.delete_binding
+        self.get_binding = self.binding.get_binding
+        self.list_bindings = self.binding.list_bindings
+        self.update_binding = self.binding.update_binding
+
+        # collection
         self.collection = CollectionClient(self)
+        self.create_collection = self.collection.add_collection
+        self.delete_collection = self.collection.delete_collection
+        self.get_collection = self.collection.get_collection
+        self.list_collections = self.collection.list_collections
+        self.update_collection = self.collection.update_collection
+
+        # document
         self.document = DocumentClient(self)
+        self.add_documents = self.document.add_documents
+        self.delete_document = self.document.delete_document
+        self.get_document = self.document.get_document
+        self.list_documents = self.document.list_documents
+        self.update_document = self.document.update_document
+
+        # index
         self.index = IndexClient(self)
+        self.create_index = self.index.add_index
+        self.delete_index = self.index.delete_index
+        self.get_index = self.index.get_index
+        self.list_indexes = self.index.list_indexes
+        self.query_index = self.index.query_index
+        self.update_index = self.index.update_index
+
+        # transformer
         self.transformer = TransformerClient(self)
+        self.create_transformer = self.transformer.add_transformer
+        self.delete_transformer = self.transformer.delete_transformer
+        self.get_transformer = self.transformer.get_transformer
+        self.list_transformers = self.transformer.list_transformers
+        self.update_transformer = self.transformer.update_transformer
 
     async def __aenter__(self) -> "LexyClient":
         """ Async context manager entry point. """
@@ -92,6 +137,36 @@ class LexyClient:
         """ Async DELETE request. """
         return await self.aclient.delete(url, **kwargs)
 
+    @property
+    def bindings(self):
+        """ Get a list of all bindings. """
+        return self.binding.list_bindings()
 
+    @property
+    def collections(self):
+        """ Get a list of all collections. """
+        return self.collection.list_collections()
 
+    @property
+    def indexes(self):
+        """ Get a list of all indexes. """
+        return self.index.list_indexes()
 
+    @property
+    def transformers(self):
+        """ Get a list of all transformers. """
+        return self.transformer.list_transformers()
+
+    def info(self):
+        """ Print info about the Lexy server. """
+        collections_str = "\n".join([f"\t- {c.__repr__()}" for c in self.collections])
+        indexes_str = "\n".join([f"\t- {i.__repr__()}" for i in self.indexes])
+        transformers_str = "\n".join([f"\t- {t.__repr__()}" for t in self.transformers])
+        bindings_str = "\n".join([f"\t- {b.__repr__()}" for b in self.bindings])
+        info_str = \
+            f"Lexy server <{self.base_url}>\n\n" \
+            f"{len(self.collections)} Collections\n{collections_str}\n" \
+            f"{len(self.indexes)} Indexes\n{indexes_str}\n" \
+            f"{len(self.transformers)} Transformers\n{transformers_str}\n" \
+            f"{len(self.bindings)} Bindings\n{bindings_str}\n"
+        print(info_str)

--- a/sdk-python/lexy_py/collection/models.py
+++ b/sdk-python/lexy_py/collection/models.py
@@ -11,7 +11,6 @@ if TYPE_CHECKING:
 
 class CollectionModel(BaseModel):
     """ Collection model """
-
     collection_id: str = Field(
         min_length=1,
         max_length=255,
@@ -22,12 +21,11 @@ class CollectionModel(BaseModel):
     updated_at: Optional[datetime] = None
 
     def __repr__(self):
-        return f"<Collection('{self.collection_id}', description={self.description})>"
+        return f"<Collection('{self.collection_id}', description='{self.description}')>"
 
 
 class CollectionUpdate(BaseModel):
     """ Collection update model """
-
     description: Optional[str] = None
 
 
@@ -45,6 +43,18 @@ class Collection(CollectionModel):
             raise ValueError("API client has not been set.")
         return self._client
 
+    def add_documents(self, docs: Document | list[Document] | dict | list[dict]) -> list[Document]:
+        """ Synchronously add documents to the collection.
+
+        Args:
+            docs (Document | list[Document] | dict | list[dict]): The documents to add.
+
+        Returns:
+            list[Document]: The added documents.
+        """
+        return self.client.document.add_documents(docs, collection_id=self.collection_id)
+
+    # TODO: add pagination
     def list_documents(self) -> list[Document]:
         """ Synchronously get all documents in the collection.
 

--- a/sdk-python/lexy_py/document/client.py
+++ b/sdk-python/lexy_py/document/client.py
@@ -61,6 +61,14 @@ class DocumentClient:
 
         Returns:
             list[Document]: A list of created documents.
+
+        Examples:
+            >>> from lexy_py import LexyClient
+            >>> lexy = LexyClient()
+            >>> docs_added = lexy.add_documents(docs=[
+            ...     {"content": "My first document"},
+            ...     {"content": "My second document"}
+            ... ], collection_id="my_collection")
         """
         processed_docs = self._process_docs(docs)
 

--- a/sdk-python/lexy_py/document/models.py
+++ b/sdk-python/lexy_py/document/models.py
@@ -18,7 +18,7 @@ class DocumentModel(BaseModel):
     collection_id: Optional[str] = None
 
     def __repr__(self):
-        return f'<Document("{textwrap.shorten(self.content, 100, placeholder="...")}", {self.document_id})>'
+        return f'<Document("{textwrap.shorten(self.content, 100, placeholder="...")}")>'
 
     def __init__(self, content: str, **data: Any):
         super().__init__(content=content, **data)


### PR DESCRIPTION
# What

- Added `examples/getting_started.ipynb` as an initial Getting Started guide.
- Assigned methods from `<Model>Client` classes to `LexyClient`.
  - For example, `LexyClient.add_documents()` in addition to `LexyClient.document.add_documents()`.
- Added an `info()` method to `LexyClient`.
- Fixed a bug where adding a binding via the client resulted in an error.


# Why

- Need documentation for getting started.
- The client is easier to use with direct access to CRUD methods, although there is a lot of repetition. Will revisit the design later.


# Test plan

- Run `pytest sdk-python` in terminal
- Run the cells in `examples/tests.ipynb`