### PR TITLE
Add cascade behavior to collection and index models.

### DIFF
--- a/lexy/models/collection.py
+++ b/lexy/models/collection.py
@@ -28,8 +28,14 @@ class Collection(CollectionBase, table=True):
     updated_at: datetime = Field(
         sa_column=Column(DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now()),
     )
-    documents: list["Document"] = Relationship(back_populates="collection", sa_relationship_kwargs={'lazy': 'subquery'})
-    bindings: list["Binding"] = Relationship(back_populates="collection", sa_relationship_kwargs={'lazy': 'selectin'})
+    documents: list["Document"] = Relationship(
+        back_populates="collection",
+        sa_relationship_kwargs={'lazy': 'subquery'}
+    )
+    bindings: list["Binding"] = Relationship(
+        back_populates="collection",
+        sa_relationship_kwargs={'lazy': 'selectin', 'cascade': 'all, delete-orphan'}
+    )
 
 
 class CollectionCreate(CollectionBase):

--- a/lexy/models/index.py
+++ b/lexy/models/index.py
@@ -34,7 +34,10 @@ class Index(IndexBase, table=True):
     updated_at: datetime = Field(
         sa_column=Column(DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now()),
     )
-    bindings: list["Binding"] = Relationship(back_populates="index")
+    bindings: list["Binding"] = Relationship(
+        back_populates="index",
+        sa_relationship_kwargs={'cascade': 'all, delete-orphan'}
+    )
     index_table_name: str = Field(
         regex=r"^[a-z0-9_-]+$",
         sa_column=Column(String, default=default_index_table_name, nullable=False, unique=True),

--- a/lexy/models/index_record.py
+++ b/lexy/models/index_record.py
@@ -1,10 +1,13 @@
 from datetime import datetime
-from typing import Any, Optional
+from typing import Any, Optional, TYPE_CHECKING
 from uuid import uuid4, UUID
 
 from sqlalchemy import Column, DateTime, ForeignKey, func
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlmodel import SQLModel, Field, Relationship
+
+if TYPE_CHECKING:
+    from lexy.models.document import Document
 
 
 class IndexRecordBase(SQLModel):


### PR DESCRIPTION
# What

The `ON DELETE CASCADE` behavior for bindings now works properly.
   - Deleting a collection will delete any associated bindings
   - Deleting an index will delete any associated bindings

# Why

Previously the binding row was being orphaned.

# Test plan

Go through the Bios example in the tutorial. Delete the `bios` collection and its associated binding should be deleted. Same thing for the `bios_index` index. 