### PR TITLE
Lazy loading of collection documents and endpoint additions

### DIFF
--- a/lexy/api/endpoints/transformers.py
+++ b/lexy/api/endpoints/transformers.py
@@ -93,8 +93,11 @@ async def delete_transformer(transformer_id: str, session: AsyncSession = Depend
              status_code=status.HTTP_200_OK,
              name="transform_document",
              description="Transform a document")
-async def transform_document(transformer_id: str, document: DocumentCreate, transformer_params: dict = None,
-                             content_only: bool = False, session: AsyncSession = Depends(get_session)) -> dict:
+async def transform_document(transformer_id: str,
+                             document: DocumentCreate,
+                             transformer_params: dict = None,
+                             content_only: bool = False,
+                             session: AsyncSession = Depends(get_session)) -> dict:
     result = await session.execute(select(Transformer).where(Transformer.transformer_id == transformer_id))
     transformer = result.scalars().first()
     if not transformer:

--- a/lexy/core/events.py
+++ b/lexy/core/events.py
@@ -132,7 +132,8 @@ def drop_index_table(index_id: str) -> bool:
     return True
 
 
-async def process_new_binding(binding: Binding, create_index_table: bool = False) \
+# TODO: remove session arg and run async after update to SQLAlchemy 2.0
+def process_new_binding(session, binding: Binding, create_index_table: bool = False) \
         -> tuple[Binding, list[dict]]:
     """ Process a new binding.
 

--- a/lexy/models/collection.py
+++ b/lexy/models/collection.py
@@ -30,7 +30,7 @@ class Collection(CollectionBase, table=True):
     )
     documents: list["Document"] = Relationship(
         back_populates="collection",
-        sa_relationship_kwargs={'lazy': 'subquery'}
+        sa_relationship_kwargs={'lazy': 'select'}
     )
     bindings: list["Binding"] = Relationship(
         back_populates="collection",

--- a/sdk-python/lexy_py/client.py
+++ b/sdk-python/lexy_py/client.py
@@ -88,6 +88,7 @@ class LexyClient:
         self.get_transformer = self.transformer.get_transformer
         self.list_transformers = self.transformer.list_transformers
         self.update_transformer = self.transformer.update_transformer
+        self.transform_document = self.transformer.transform_document
 
     async def __aenter__(self) -> "LexyClient":
         """ Async context manager entry point. """

--- a/sdk-python/lexy_py/collection/models.py
+++ b/sdk-python/lexy_py/collection/models.py
@@ -55,10 +55,14 @@ class Collection(CollectionModel):
         return self.client.document.add_documents(docs, collection_id=self.collection_id)
 
     # TODO: add pagination
-    def list_documents(self) -> list[Document]:
-        """ Synchronously get all documents in the collection.
+    def list_documents(self, limit: int = 100, offset: int = 0) -> list[Document]:
+        """ Synchronously get a list of documents in the collection.
+
+        Args:
+            limit (int): The maximum number of documents to return. Defaults to 100. Maximum allowed is 1000.
+            offset (int): The offset to start from. Defaults to 0.
 
         Returns:
-            Documents: A list of all documents in the collection.
+            Documents: A list of documents in the collection.
         """
-        return self.client.document.list_documents(self.collection_id)
+        return self.client.document.list_documents(self.collection_id, limit=limit, offset=offset)

--- a/sdk-python/lexy_py/document/client.py
+++ b/sdk-python/lexy_py/document/client.py
@@ -26,29 +26,49 @@ class DocumentClient:
         self.aclient = self._lexy_client.aclient
         self.client = self._lexy_client.client
 
-    def list_documents(self, collection_id: str = "default") -> list[Document]:
-        """ Synchronously get a list of all documents in a collection.
+    def list_documents(self,
+                       collection_id: str = "default",
+                       limit: int = 100,
+                       offset: int = 0) -> list[Document]:
+        """ Synchronously get a list of documents in a collection.
 
         Args:
             collection_id (str): The ID of the collection to get documents from. Defaults to "default".
+            limit (int): The maximum number of documents to return. Defaults to 100. Maximum allowed is 1000.
+            offset (int): The offset to start from. Defaults to 0.
 
         Returns:
-            list[Document]: A list of all documents in a collection.
+            list[Document]: A list of documents in a collection.
         """
-        r = self.client.get("/documents", params={"collection_id": collection_id})
+        r = self.client.get("/documents",
+                            params={
+                                "collection_id": collection_id,
+                                "limit": limit,
+                                "offset": offset
+                            })
         handle_response(r)
         return [Document(**document, client=self._lexy_client) for document in r.json()]
 
-    async def alist_documents(self, collection_id: str = "default") -> list[Document]:
-        """ Asynchronously get a list of all documents in a collection.
+    async def alist_documents(self,
+                              collection_id: str = "default",
+                              limit: int = 100,
+                              offset: int = 0) -> list[Document]:
+        """ Asynchronously get a list of documents in a collection.
 
         Args:
             collection_id (str): The ID of the collection to get documents from. Defaults to "default".
+            limit (int): The maximum number of documents to return. Defaults to 100. Maximum allowed is 1000.
+            offset (int): The offset to start from. Defaults to 0.
 
         Returns:
-            list[Document]: A list of all documents in a collection.
+            list[Document]: A list of documents in a collection.
         """
-        r = await self.aclient.get("/documents", params={"collection_id": collection_id})
+        r = await self.aclient.get("/documents",
+                                   params={
+                                       "collection_id": collection_id,
+                                       "limit": limit,
+                                       "offset": offset
+                                   })
         handle_response(r)
         return [Document(**document, client=self._lexy_client) for document in r.json()]
 
@@ -202,6 +222,16 @@ class DocumentClient:
             document_id (str): The ID of the document to delete.
         """
         r = await self.aclient.delete(f"/documents/{document_id}")
+        handle_response(r)
+        return r.json()
+
+    def bulk_delete_documents(self, collection_id: str) -> dict:
+        """ Synchronously delete all documents from a collection.
+
+        Args:
+            collection_id (str): The ID of the collection to delete documents from.
+        """
+        r = self.client.delete("/documents", params={"collection_id": collection_id})
         handle_response(r)
         return r.json()
 

--- a/sdk-python/lexy_py/index/client.py
+++ b/sdk-python/lexy_py/index/client.py
@@ -251,8 +251,13 @@ class IndexClient:
         handle_response(r)
         return r.json()
 
-    def query_index(self, query_string: str, index_id: str = "default_text_embeddings", query_field: str = "embedding",
-                    k: int = 5) -> list[dict]:
+    def query_index(self,
+                    query_string: str,
+                    index_id: str = "default_text_embeddings",
+                    query_field: str = "embedding",
+                    k: int = 5,
+                    return_fields: list[str] = None,
+                    return_doc_content: bool = False) -> list[dict]:
         """ Synchronously query an index.
 
         Args:
@@ -260,22 +265,32 @@ class IndexClient:
             index_id (str): The ID of the index to query. Defaults to "default_text_embeddings".
             query_field (str, optional): The field to query. Defaults to "embedding".
             k (int, optional): The number of records to return. Defaults to 5.
+            return_fields (list[str], optional): The fields to return. Defaults to None, which returns all fields.
+            return_doc_content (bool, optional): Whether to return the document content. Defaults to False.
 
         Returns:
             list[dict]: The query results.
         """
+        if return_fields is None:
+            return_fields = []
         params = {
             "query_string": query_string,
             "query_field": query_field,
-            "k": k
+            "k": k,
+            "return_fields": return_fields,
+            "return_doc_content": return_doc_content
         }
         r = self.client.get(f"/indexes/{index_id}/records/query", params=params)
         handle_response(r)
         return r.json()["search_results"]
 
-    async def aquery_index(self, query_string: str, index_id: str = "default_text_embeddings",
-                           query_field: str = "embedding", k: int = 5) \
-            -> list[dict]:
+    async def aquery_index(self,
+                           query_string: str,
+                           index_id: str = "default_text_embeddings",
+                           query_field: str = "embedding",
+                           k: int = 5,
+                           return_fields: list[str] = None,
+                           return_doc_content: bool = False) -> list[dict]:
         """ Asynchronously query an index.
 
         Args:
@@ -283,14 +298,20 @@ class IndexClient:
             index_id (str): The ID of the index to query. Defaults to "default_text_embeddings".
             query_field (str, optional): The field to query. Defaults to "embedding".
             k (int, optional): The number of records to return. Defaults to 5.
+            return_fields (list[str], optional): The fields to return. Defaults to None, which returns all fields.
+            return_doc_content (bool, optional): Whether to return the document content. Defaults to False.
 
         Returns:
             list[dict]: The query results.
         """
+        if return_fields is None:
+            return_fields = []
         params = {
             "query_string": query_string,
             "query_field": query_field,
-            "k": k
+            "k": k,
+            "return_fields": return_fields,
+            "return_doc_content": return_doc_content
         }
         r = await self.aclient.get(f"/indexes/{index_id}/records/query", params=params)
         handle_response(r)

--- a/sdk-python/lexy_py/index/models.py
+++ b/sdk-python/lexy_py/index/models.py
@@ -42,18 +42,30 @@ class Index(IndexModel):
             raise ValueError("API client has not been set.")
         return self._client
 
-    def query(self, query_string: str, query_field: str = "embedding", k: int = 5) -> list[dict]:
+    def query(self,
+              query_string: str,
+              query_field: str = "embedding",
+              k: int = 5,
+              return_fields: list[str] = None,
+              return_doc_content: bool = False) -> list[dict]:
         """ Synchronously query an index.
 
         Args:
             query_string (str): The query string.
             query_field (str, optional): The field to query. Defaults to "embedding".
             k (int, optional): The number of records to return. Defaults to 5.
+            return_fields (list[str], optional): The fields to return. Defaults to None, which returns all fields.
+            return_doc_content (bool, optional): Whether to return the document content. Defaults to False.
 
         Returns:
             Results: A list of query results.
         """
-        return self.client.index.query_index(query_string, self.index_id, query_field, k)
+        return self.client.index.query_index(query_string=query_string,
+                                             index_id=self.index_id,
+                                             query_field=query_field,
+                                             k=k,
+                                             return_fields=return_fields,
+                                             return_doc_content=return_doc_content)
 
     def list_records(self, document_id: Optional[str] = None) -> list[dict]:
         """ Synchronously list all records in the index.

--- a/sdk-python/lexy_py/transformer/models.py
+++ b/sdk-python/lexy_py/transformer/models.py
@@ -3,6 +3,8 @@ from typing import Any, Optional, TYPE_CHECKING
 
 from pydantic import BaseModel, Field, PrivateAttr
 
+from lexy_py.document.models import Document
+
 if TYPE_CHECKING:
     from lexy_py.client import LexyClient
 
@@ -38,3 +40,31 @@ class Transformer(TransformerModel):
         if not self._client:
             raise ValueError("API client has not been set.")
         return self._client
+
+    def transform_document(self,
+                           document: Document | dict,
+                           transformer_params: dict = None,
+                           content_only: bool = False) -> dict:
+        """ Synchronously transform a document.
+
+        Args:
+            document (Document | dict): The document to transform.
+            transformer_params (dict, optional): The transformer parameters. Defaults to None.
+            content_only (bool, optional): Whether to submit only the document content and not the document itself.
+                Use this option when the transformer doesn't accept Document objects as inputs. Defaults to False.
+
+        Returns:
+            dict: A dictionary containing the generated task ID and the result of the transformer.
+
+        Examples:
+            >>> from lexy_py import LexyClient
+            >>> lexy = LexyClient()
+            >>> minilm = lexy.get_transformer('text.embeddings.minilm')
+            >>> minilm.transform_document({'content': 'Good morning!'})
+            {'task_id': '449d9d79-4a57-4191-95d3-9c38955c8ced',
+             'result': [-0.03085244633257389, 0.028894789516925812, ...]}
+        """
+        return self.client.transformer.transform_document(transformer_id=self.transformer_id,
+                                                          document=document,
+                                                          transformer_params=transformer_params,
+                                                          content_only=content_only)

--- a/sdk-python/lexy_py_tests/test_transformer.py
+++ b/sdk-python/lexy_py_tests/test_transformer.py
@@ -48,3 +48,10 @@ class TestTransformerClient:
     async def test_alist_transformers(self):
         transformers = await lexy.transformer.alist_transformers()
         assert len(transformers) > 0
+
+    def test_transform_document(self):
+        transformer = lexy.transformer.get_transformer("text.embeddings.minilm")
+        response = transformer.transform_document({"content": "Hello, world!"})
+        assert 'task_id' in response
+        assert isinstance(response["result"], list)
+        assert all(isinstance(elem, float) for elem in response["result"])


### PR DESCRIPTION
# What

- Collection documents are now lazily loaded. 
- Added limit-offset args for `get_documents`.
- New bulk delete documents endpoint.
- Added return field options for index queries. 
- Added client method for transform document endpoint.

# Why

Performance issues when using a large enough collection.

# Test plan

Run `pytest sdk-python` in terminal.
