### PR TITLE
[Tutorial] Argument in index.query() should be query_text instead of query_string

### DIFF
--- a/examples/tutorial.ipynb
+++ b/examples/tutorial.ipynb
@@ -380,7 +380,7 @@
    },
    "outputs": [],
    "source": [
-    "index.query(query_string='famous artists', query_field='bio_embedding', k=3)"
+    "index.query(query_text='famous artists', query_field='bio_embedding', k=3)"
    ]
   },
   {
@@ -424,7 +424,7 @@
    },
    "outputs": [],
    "source": [
-    "index.query(query_string='famous artists', query_field='bio_embedding', k=3)"
+    "index.query(query_text='famous artists', query_field='bio_embedding', k=3)"
    ]
   },
   {


### PR DESCRIPTION
# What
Small fixes in two callsites of `index.query()` in tutorial.ipynb.

# Why
The argument in `index.query()` should be `query_text` instead of `query_string`

# Test plan
Verified manually that the tutorial works correctly now.
