### PR TITLE
Bugfix for postgres host in GlobalConfig

### DIFF
--- a/lexy/core/config.py
+++ b/lexy/core/config.py
@@ -42,7 +42,7 @@ class GlobalConfig(BaseConfig):
     # Database settings
     postgres_user: str = os.environ.get("POSTGRES_USER", "postgres")
     postgres_password: str = os.environ.get("POSTGRES_PASSWORD", "postgres")
-    postgres_host: str = os.environ.get("POSTGRES_HOST", "db_postgres")
+    postgres_host: str = os.environ.get("POSTGRES_HOST", "localhost")
     # postgres_port: int = int(os.environ.get("POSTGRES_PORT"))
     postgres_db: str = os.environ.get("POSTGRES_DB", "lexy")
     # db_url = os.environ.get("DATABASE_URL")


### PR DESCRIPTION
# What

- Previously running `alembic upgrade head` without exporting `POSTGRES_HOST=localhost` would cause an error.
- Can now run this command locally, and should no longer need to configure IDE or notebooks with a POSTGRES_HOST environment variable.

# Why

POSTGRES_HOST was defaulting to `db_postgres` instead of `localhost`, which is the value set inside of docker.

# Test plan

- [x] Run `pytest sdk-python`
- [x] Run `examples/tests.ipynb` and verify that there are no errors
- [ ] Run `examples/tutorial.ipynb` and verify that the tutorial works as expected
- [ ] Run `examples/images.ipynb` and verify that the tutorial works as expected
