### PR TITLE
Added the janky version of openai embeddings

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,22 @@ You'll also need to specify an S3 bucket for file storage (for which your AWS cr
 You can do so by adding `S3_BUCKET=<name-of-your-S3-bucket>` to your `.env` file, or by updating the value of 
 `s3_bucket` in `lexy/core/config.py`.
 
+### Using OpenAI transformers
+
+To use OpenAI embeddings in Lexy, you'll need to set the `OPENAI_API_KEY` environment variable. You can do so by adding 
+the following to your `.env` file:
+
+```Shell
+OPENAI_API_KEY=<your-openai-api-key>
+```
+
+Do this before building your docker containers. Or, if you've already run `docker-compose up`, you can run the 
+following to rebuild the server and worker containers.
+
+```shell
+docker-compose up --build -d --no-deps lexyserver lexyworker
+```
+
 ### PyCharm issues
 
 If your virtualenv keeps getting bjorked by PyCharm, make sure that you're following the instructions above verbatim, 

--- a/lexy/api/endpoints/index_records.py
+++ b/lexy/api/endpoints/index_records.py
@@ -99,7 +99,10 @@ async def query_records(query_text: str = Form(None),
                             detail=f"Transformer '{embedding_model}' not found")
     task = celery.send_task(transformer.celery_task_name, args=[query], priority=10)
     result = task.get()
-    query_embedding = result.tolist()
+    if isinstance(result, list):
+        query_embedding = result
+    else:
+        query_embedding = result.tolist()
 
     # get index fields to return
     if return_fields:

--- a/lexy/core/config.py
+++ b/lexy/core/config.py
@@ -70,12 +70,14 @@ class GlobalConfig(BaseConfig):
         'lexy.transformers.counter',
         'lexy.transformers.embeddings',
         'lexy.transformers.multimodal',
+        'lexy.transformers.openai',
     }
     lexy_worker_transformer_imports = {
         # 'lexy.transformers.*'
         'lexy.transformers.counter',
         'lexy.transformers.embeddings',
         'lexy.transformers.multimodal',
+        'lexy.transformers.openai',
     }
 
     @property

--- a/lexy/db/sample_data.py
+++ b/lexy/db/sample_data.py
@@ -26,6 +26,11 @@ default_data = {
             "description": "Image embeddings using \"openai/clip-vit-base-patch32\""
         },
         {
+            "transformer_id": "text.embeddings.openai-ada-002",
+            "path": "lexy.transformers.openai.text_embeddings_openai",
+            "description": "Text embeddings using OpenAI's \"text-embedding-ada-002\" model"
+        },
+        {
             "transformer_id": "text.counter.word_counter",
             "path": "lexy.transformers.counter.word_counter",
             "description": "Returns count of words and the longest word"

--- a/lexy/models/transformer.py
+++ b/lexy/models/transformer.py
@@ -19,7 +19,7 @@ class TransformerBase(SQLModel):
         primary_key=True,
         min_length=1,
         max_length=255,
-        regex=r"^[a-zA-Z][a-zA-Z0-9_.]+$"
+        regex=r"^[a-zA-Z][a-zA-Z0-9_.-]+$"
     )
     path: Optional[str] = Field(
         default=None,

--- a/lexy/transformers/openai.py
+++ b/lexy/transformers/openai.py
@@ -1,0 +1,57 @@
+import logging
+import os
+
+from openai import OpenAI
+
+from lexy.models.document import DocumentBase
+from lexy.transformers import lexy_transformer
+
+
+logger = logging.getLogger(__name__)
+if os.environ.get("OPENAI_API_KEY"):
+    openai_client = OpenAI(api_key=os.environ["OPENAI_API_KEY"])
+else:
+    openai_client = None
+    logger.warning("OPENAI_API_KEY not set; cannot use OpenAI API")
+
+
+@lexy_transformer(name="text.embeddings.openai-ada-002")
+def text_embeddings_openai(text: list[str | DocumentBase] | str | DocumentBase, **kwargs) \
+        -> list[list[float]] | list[float]:
+    """Embed text using OpenAI's API.
+
+    Any additional keyword arguments are passed to the client's `OpenAI.embeddings.create` method.
+
+    Args:
+        text: A single string or DocumentBase instance, or a list of strings or DocumentBase instances to embed.
+
+    Keyword Args:
+        encoding_format: The format to return the embeddings in. Can be either float or
+            [base64](https://pypi.org/project/pybase64/).
+        user: A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
+        extra_headers: Send extra headers
+        extra_query: Add additional query parameters to the request
+        extra_body: Add additional JSON properties to the request
+        timeout: Override the client-level default timeout for this request, in seconds
+
+    Returns:
+        list[list[float]] | list[float]: The embeddings of the provided text.
+    """
+    if not openai_client:
+        raise Exception("OPENAI_API_KEY not set; cannot use OpenAI API")
+
+    if isinstance(text, DocumentBase):
+        text = text.content
+    elif isinstance(text, list):
+        text = [s.content if isinstance(s, DocumentBase) else s for s in text]
+
+    api_response = openai_client.embeddings.create(
+        model="text-embedding-ada-002",
+        input=text,
+        **kwargs
+    )
+
+    if isinstance(text, list):
+        return [e.embedding for e in api_response.data]
+    else:
+        return api_response.data[0].embedding

--- a/poetry.lock
+++ b/poetry.lock
@@ -458,6 +458,17 @@ files = [
 ]
 
 [[package]]
+name = "distro"
+version = "1.9.0"
+description = "Distro - an OS platform information API"
+optional = true
+python-versions = ">=3.6"
+files = [
+    {file = "distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2"},
+    {file = "distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed"},
+]
+
+[[package]]
 name = "docutils"
 version = "0.16"
 description = "Docutils -- Python Documentation Utilities"
@@ -1264,6 +1275,29 @@ files = [
     {file = "numpy-1.25.2-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:1b9735c27cea5d995496f46a8b1cd7b408b3f34b6d50459d9ac8fe3a20cc17bf"},
     {file = "numpy-1.25.2.tar.gz", hash = "sha256:fd608e19c8d7c55021dffd43bfe5492fab8cc105cc8986f813f8c3c048b38760"},
 ]
+
+[[package]]
+name = "openai"
+version = "1.7.2"
+description = "The official Python library for the openai API"
+optional = true
+python-versions = ">=3.7.1"
+files = [
+    {file = "openai-1.7.2-py3-none-any.whl", hash = "sha256:8f41b90a762f5fd9d182b45851041386fed94c8ad240a70abefee61a68e0ef53"},
+    {file = "openai-1.7.2.tar.gz", hash = "sha256:c73c78878258b07f1b468b0602c6591f25a1478f49ecb90b9bd44b7cc80bce73"},
+]
+
+[package.dependencies]
+anyio = ">=3.5.0,<5"
+distro = ">=1.7.0,<2"
+httpx = ">=0.23.0,<1"
+pydantic = ">=1.9.0,<3"
+sniffio = "*"
+tqdm = ">4"
+typing-extensions = ">=4.7,<5"
+
+[package.extras]
+datalib = ["numpy (>=1)", "pandas (>=1.2.3)", "pandas-stubs (>=1.1.0.11)"]
 
 [[package]]
 name = "packaging"
@@ -2787,9 +2821,9 @@ files = [
 ]
 
 [extras]
-lexy-transformers = ["sentence-transformers", "transformers"]
+lexy-transformers = ["openai", "sentence-transformers", "transformers"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "77a8042f2463e6d66a6b71eef6bac94740744e82f9ac4518a98b7d1a98f6b919"
+content-hash = "fc3e7eb11a6047ad9d5dfbef46d0d1b13b578b570b35bfa8443e8ae2fbcd5956"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,9 +24,10 @@ Pillow = "^10.0.1"
 # optional dependencies
 transformers = { version = "^4.33.1", extras = ["torch"], optional = true}
 sentence-transformers = { version = "^2.2.2", optional = true}
+openai = { version = "^1.7.1", optional = true}
 
 [tool.poetry.extras]
-lexy_transformers = ["transformers", "sentence-transformers"]
+lexy_transformers = ["transformers", "sentence-transformers", "openai"]
 
 [tool.poetry.group.dev.dependencies]
 alembic = "^1.13.1"

--- a/sdk-python/lexy_py/transformer/models.py
+++ b/sdk-python/lexy_py/transformer/models.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 
 class TransformerModel(BaseModel):
     """ Transformer model """
-    transformer_id: str = Field(..., min_length=1, max_length=255, regex=r"^[a-zA-Z][a-zA-Z0-9_.]+$")
+    transformer_id: str = Field(..., min_length=1, max_length=255, regex=r"^[a-zA-Z][a-zA-Z0-9_.-]+$")
     path: Optional[str] = Field(..., min_length=1, max_length=255, regex=r"^[a-zA-Z][a-zA-Z0-9_.]+$")
     description: Optional[str] = None
     created_at: Optional[datetime] = None


### PR DESCRIPTION
# What

Added a transformer for OpenAI embeddings. 

It's currently janky in that you can only pass one sentence at a time when using it in a binding. We'll have to fix this by updating `lexy.core.celery_tasks.save_records_to_index` so that it accepts additional types of mappings/sequences. More to come.

## Minimal example

```python
from lexy_py import LexyClient

lx = LexyClient()

# create collection
collection = lx.create_collection('openai_collection')

# create index
index_fields = {
    "text": {"type": "string"},
    "embedding": {"type": "embedding", "extras": {"dims": 1536, "model": "text.embeddings.openai-ada-002"}}
}
index = lx.create_index(
    index_id='openai_text_embeddings',
    description='OpenAI text embeddings',
    index_fields=index_fields
)

# create binding
binding = lx.create_binding(
    collection_id='openai_collection',
    transformer_id='text.embeddings.openai-ada-002',
    index_id='openai_text_embeddings',
    description='OpenAI text embeddings',
    transformer_params=dict(lexy_index_fields=['embedding'])
)

# add documents
collection.add_documents([
    {"content": "OpenAI is an artificial intelligence company based in San Francisco."},
    {"content": "Lexy is a data platform for building AI powered applications."}
])

# query index
index.query('AI companies')
``` 

# Why

Most people start off using embeddings from OpenAI.

# Test plan

- [x] Run `pytest sdk-python`
- [x] Run `examples/tests.ipynb` and verify that there are no errors
- [x] Run `examples/tutorial.ipynb` and verify that the tutorial works as expected
- [ ] Run `examples/images.ipynb` and verify that the tutorial works as expected
