### PR TITLE
Add CORS middleware for front-end

### DIFF
--- a/lexy/main.py
+++ b/lexy/main.py
@@ -1,6 +1,7 @@
 import importlib
 
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 
 from lexy.core.celery_app import create_celery
 from lexy.core.config import settings
@@ -25,9 +26,25 @@ def create_app() -> FastAPI:
     return fastapi_app
 
 
+# Create FastAPI app
 app = create_app()
+
+# Create Celery app
 app.celery_app = create_celery()
 celery = app.celery_app
+
+# Add CORS middleware
+origins = [
+    "http://localhost",
+    "http://localhost:3000",
+]
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=origins,
+    allow_credentials=True,
+    allow_methods=["*"],  # allow all methods
+    allow_headers=["*"],  # allow all headers
+)
 
 
 @app.on_event("startup")


### PR DESCRIPTION
# What

Added CORS middleware with localhost origins.

# Why

Front-end at [lexy-land](https://github.com/lexy-ai/lexy-land) needs to load on port 3000.

# Test plan

- [ ] Run `pytest sdk-python`
- [ ] Run `examples/tests.ipynb` and verify that there are no errors
- [ ] Run `examples/tutorial.ipynb` and verify that the tutorial works as expected
- [ ] Run `examples/images.ipynb` and verify that the tutorial works as expected
