### PR TITLE
Add batching on the client

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+# Since the ".env" file is gitignored, you can use the ".env.example" file to
+# build a new ".env" file when you clone the repo. Keep this file up-to-date
+# when you add new variables to `.env`.
+
+# This file will be committed to version control, so make sure not to have any
+# secrets in it. If you are cloning this repo, create a copy of this file named
+# ".env" and populate it with your secrets.
+
+# Example:
+# OPENAI_API_KEY=your_secret_key
+# S3_BUCKET=your_s3_bucket_name
+# GITHUB_TOKEN=your_github_personal_access_token

--- a/docs/docs/faq.md
+++ b/docs/docs/faq.md
@@ -1,0 +1,24 @@
+# Frequently Asked Questions
+
+## How do I add a new environment variable?
+
+To add a new environment variable, add it to your `.env` file. If you don't have a `.env` file, you can simply create 
+it by running `cp .env.example .env`. Then, open the `.env` file and add your new environment variable.
+
+You should add environment variables **before** building your docker containers. Or, if you have already built your
+containers, you can run the following to rebuild the server and worker containers. 
+
+```bash
+docker-compose up --build -d --no-deps lexyserver lexyworker
+```
+
+## Why is Lexy written in Python? Isn't Python too slow?
+
+We chose Python because it is a language that is easy to read and write, is popular in the data and machine learning
+communities, and is great for orchestration of complex systems. It's not yet clear what the biggest bottlenecks will be
+in terms of performance, but we are confident that we can optimize performance using C/C++ bindings. And if that doesn't
+work we'll just RIIR.
+
+## I think the name Lexy is super cool!
+
+We agree with you!

--- a/docs/docs/tutorials/rag.md
+++ b/docs/docs/tutorials/rag.md
@@ -1,0 +1,35 @@
+# What's the point of AGI?
+
+We know what you're thinking. "What's the point of AGI? IDGAF bruh!". 
+
+Well, we're here to tell you that you should GAF. AGI is the future of AI. It's the next step in the evolution of AI. 
+It's the next step in the evolution of humanity. It's the next step in the evolution of the universe. It's the next 
+step in the evolution of everything. 
+
+☝️ Btw, that last paragraph was written by Github Copilot. 
+
+## What's RAG?
+
+## What's the point of RAG?
+
+## How is RAG different from search?
+
+## RAG vs fine-tuning
+
+### Advantages of RAG
+
+* Changes to information
+* Auth and permissions
+
+### Limitations of RAG
+
+* Foundational vs retrieved knowledge (ie, knowing when to RAG)
+* Context length
+* Retrieval quality
+
+### Example of RAG vs fine-tuning
+
+NBA roster.
+
+Show 1000 fine-tuning runs to update the player roster, and show the log probs of each player.
+Vs RAG, where you can just retrieve the player roster from a DB.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -101,6 +101,7 @@ nav:
     - Multimodal image search: tutorials/multimodal-image-search.md
     - Custom transformers: tutorials/custom-transformers.md
     - Document filters: tutorials/document-filters.md
+    - Basic RAG using Lexy: tutorials/rag.md
   - Lexy API:
     - Overview: reference/lexy_api/overview.md
   - Python SDK:
@@ -111,6 +112,7 @@ nav:
     - Filters: reference/lexy_py/filters.md
     - Index: reference/lexy_py/indexes.md
     - Transformer: reference/lexy_py/transformer.md
+  - FAQ: faq.md
 
 extra:
   generator: false

--- a/examples/tests.ipynb
+++ b/examples/tests.ipynb
@@ -440,6 +440,38 @@
    "execution_count": null,
    "outputs": [],
    "source": [
+    "# upload documents in batches\n",
+    "more_img_docs = junk_images_collection.upload_documents(\n",
+    "    files=[\n",
+    "        '../sample_data/images/lexy-dalle.jpeg',\n",
+    "        '../sample_data/images/lexy.png',\n",
+    "        '../sample_data/images/lexy-dalle.jpeg',\n",
+    "    ],\n",
+    "    filenames=['junk1.jpeg', 'junk2.jpeg', 'junk3.jpeg'],\n",
+    "    batch_size=2,\n",
+    ")\n",
+    "more_img_docs"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "assert len(more_img_docs) == 3"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
     "lexy.delete_collection('junk_images', delete_documents=True)"
    ],
    "metadata": {

--- a/sdk-python/lexy_py/collection/models.py
+++ b/sdk-python/lexy_py/collection/models.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from typing import Any, Optional, TYPE_CHECKING
 
+from PIL import Image
 from pydantic import BaseModel, Field, PrivateAttr
 
 from lexy_py.document.models import Document
@@ -45,16 +46,19 @@ class Collection(CollectionModel):
             raise ValueError("API client has not been set.")
         return self._client
 
-    def add_documents(self, docs: Document | dict | list[Document | dict]) -> list[Document]:
-        """ Synchronously add documents to the collection.
+    def add_documents(self,
+                      docs: Document | dict | list[Document | dict],
+                      batch_size: int = 100) -> list[Document]:
+        """ Synchronously add documents to the collection in batches.
 
         Args:
             docs (Document | dict | list[Document | dict]): The documents to add.
+            batch_size (int): The number of documents to add in each batch. Defaults to 100.
 
         Returns:
-            Documents: A list of added documents.
+            Documents: A list of created documents.
         """
-        return self.client.document.add_documents(docs, collection_id=self.collection_id)
+        return self.client.document.add_documents(docs, collection_id=self.collection_id, batch_size=batch_size)
 
     # TODO: add pagination
     def list_documents(self, limit: int = 100, offset: int = 0) -> list[Document]:
@@ -68,3 +72,23 @@ class Collection(CollectionModel):
             Documents: A list of documents in the collection.
         """
         return self.client.document.list_documents(self.collection_id, limit=limit, offset=offset)
+
+    def upload_documents(self,
+                         files: Image.Image | str | list[Image.Image | str],
+                         filenames: str | list[str] = None,
+                         batch_size: int = 5) -> list[Document]:
+        """ Synchronously upload files to the collection in batches.
+
+        Args:
+            files (Image.Image | str | list[Image.Image | str]): The files to upload. Can be a list or single instance
+                of either an Image file or a string containing the path to an Image file.
+            filenames (str | list[str], optional): The filenames of the files to upload. Defaults to None.
+            batch_size (int): The number of files to upload in each batch. Defaults to 5.
+
+        Returns:
+            Documents: A list of created documents.
+        """
+        return self.client.document.upload_documents(files=files,
+                                                     filenames=filenames,
+                                                     collection_id=self.collection_id,
+                                                     batch_size=batch_size)

--- a/sdk-python/lexy_py_tests/test_document.py
+++ b/sdk-python/lexy_py_tests/test_document.py
@@ -110,3 +110,30 @@ class TestDocumentClient:
         # delete test collection
         response = lexy.collection.delete_collection("tmp_collection")
         assert response.get("Say") == "Collection deleted!"
+
+    def test_add_documents_in_batches(self):
+        # create a test collection for testing adding documents in batches
+        tmp_collection = lexy.collection.add_collection("tmp_collection", "Temp collection")
+        assert tmp_collection.collection_id == "tmp_collection"
+
+        # add documents to the test collection
+        docs_added = lexy.document.add_documents(
+            docs=[
+                {"content": "Test Document 1 Content"},
+                {"content": "Test Document 2 Content"},
+                {"content": "Test Document 3 Content"},
+            ],
+            collection_id="tmp_collection",
+            batch_size=2)
+        assert len(docs_added) == 3
+        assert docs_added[-1].document_id is not None
+        assert docs_added[-1].content == "Test Document 3 Content"
+
+        # delete test documents
+        response = lexy.document.bulk_delete_documents(collection_id="tmp_collection")
+        assert response.get("Say") == "Documents deleted!"
+        assert response.get("deleted_count") == 3
+
+        # delete test collection
+        response = lexy.collection.delete_collection("tmp_collection")
+        assert response.get("Say") == "Collection deleted!"


### PR DESCRIPTION
# What

The client methods for `add_documents` and `upload_documents` now support batching. Also added `upload_documents` as a method on the `Collection` model.

There's also an updated example coming in the [lexy-examples](https://github.com/lexy-ai/lexy-examples) repo that makes use of client side batching.

# Why

Because the people want to add their documents in batches.

# Test plan

- [x] Run `pytest sdk-python`
- [x] Run `examples/tests.ipynb` and verify that there are no errors
- [ ] Run `examples/tutorial.ipynb` and verify that the tutorial works as expected
- [ ] Run `examples/images.ipynb` and verify that the tutorial works as expected
