### PR TITLE
Code search example continued

### DIFF
--- a/examples/code_search.ipynb
+++ b/examples/code_search.ipynb
@@ -744,11 +744,175 @@
    "id": "e8d4cb069cf40506"
   },
   {
+   "cell_type": "markdown",
+   "source": [
+    "### Testing the new transformer"
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "f7115ee62e977d81"
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "outputs": [],
    "source": [
-    "#TODO: the things you get from Lexy include the following..."
+    "code_transformer = lx.get_transformer('code.extract_comments.v1')"
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "4d831b6fb04d7c69"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "sample_content = ('\"\"\" This is a module docstring. \"\"\"\\n'\n",
+    "                  '\\n'\n",
+    "                  '# This is a comment\\n'\n",
+    "                  'class MyClass:\\n'\n",
+    "                  '   \"\"\" This is a class docstring. \"\"\"\\n'\n",
+    "                  '   def __init__():\\n'\n",
+    "                  '       # TODO: implement this\\n'\n",
+    "                  '       pass\\n'\n",
+    "                  '')\n",
+    "\n",
+    "sample_doc = {\n",
+    "    'content': sample_content, \n",
+    "    'meta': {\n",
+    "        'file_name': 'example.py',\n",
+    "        'file_ext': '.py'\n",
+    "    }\n",
+    "}"
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "673c43b89eb33cbe"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "code_transformer.transform_document(sample_doc)"
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "9411078724efb11f"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "py_doc_id = '30bbb9e1-2f9d-484a-b0d3-409a65fcfdd5'\n",
+    "py_doc = lx.get_document(py_doc_id)\n",
+    "py_doc"
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "5451bad3bda6fdff"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "code_transformer.transform_document(py_doc)"
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "964b8ec0fa11e886"
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Create an index to store the results"
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "72efb44909d14928"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# define index fields\n",
+    "index_fields = {\n",
+    "    \"comment_text\": {\"type\": \"string\"},\n",
+    "    \"comment_embedding\": {\"type\": \"embedding\", \"extras\": {\"dims\": 384, \"model\": \"text.embeddings.minilm\"}},\n",
+    "    \"comment_meta\": {\"type\": \"object\"}\n",
+    "}\n",
+    "\n",
+    "# create index\n",
+    "code_index = lx.create_index(\n",
+    "    index_id='github_code_comments',\n",
+    "    description='Comments and docstrings from code in GitHub repositories',\n",
+    "    index_fields=index_fields\n",
+    ")\n",
+    "code_index"
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "13349634011b0fe7"
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Create a binding to run the transformer on all documents\n",
+    "\n",
+    "**NOTE**: This will time out if you have a large number of documents. We need to make the initial batch of jobs run asynchronously, and return the binding in \"pending\" state with number of documents being processed."
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "76a4f2734c87eb4"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "binding = lx.create_binding(\n",
+    "    collection_id='github_repos', \n",
+    "    transformer_id='code.extract_comments.v1', \n",
+    "    index_id='github_code_comments', \n",
+    "    transformer_params={'lexy_index_fields': None}\n",
+    ")"
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "c14ad1ee88e9c109"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "binding"
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "52ecb8ec0ab26a19"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# TODO: the things you get from Lexy include the following..."
    ],
    "metadata": {
     "collapsed": false
@@ -769,11 +933,23 @@
    "cell_type": "code",
    "execution_count": null,
    "outputs": [],
-   "source": [],
+   "source": [
+    "code_index.query(query_text='qv clipping', query_field='comment_embedding')"
+   ],
    "metadata": {
     "collapsed": false
    },
    "id": "9f35b72537561896"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "780d71ef88268ce3"
   }
  ],
  "metadata": {

--- a/sdk-python/lexy_py/document/client.py
+++ b/sdk-python/lexy_py/document/client.py
@@ -380,7 +380,7 @@ class DocumentClient:
 
     @staticmethod
     def _process_docs(docs: Document | dict | list[Document | dict]) -> list[dict]:
-        """ Process documents into a list of dictionaries. """
+        """ Process documents into a list of json-serializable dictionaries. """
         processed_docs = []
 
         if isinstance(docs, (Document, dict)):

--- a/sdk-python/lexy_py/transformer/client.py
+++ b/sdk-python/lexy_py/transformer/client.py
@@ -1,5 +1,6 @@
 """ Client for interacting with the Transformer API. """
 
+import json
 from typing import Optional, TYPE_CHECKING
 
 import httpx
@@ -187,7 +188,8 @@ class TransformerClient:
         """
         if isinstance(document, dict):
             document = Document(**document)
-        data = {"document": document.dict()}
+        # TODO: use document.model_dump(mode='json') after updating to Pydantic 2.0
+        data = {"document": json.loads(document.json())}
         if transformer_params:
             data["transformer_params"] = transformer_params
         if content_only:


### PR DESCRIPTION
# What

- Additional WIP on code search example. 
- Fixed a lexy-py bug with transform_document.
  - Was not working with existing docs because datetime fields were not being converted.

# Why

N/A

# Test plan

- [ ] Run `pytest sdk-python`
- [ ] Run `examples/tests.ipynb` and verify that there are no errors
- [ ] Run `examples/tutorial.ipynb` and verify that the tutorial works as expected
- [ ] Run `examples/images.ipynb` and verify that the tutorial works as expected
