### PR TITLE
User model with OAuth2 and JWT

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,12 @@
 # secrets in it. If you are cloning this repo, create a copy of this file named
 # ".env" and populate it with your secrets.
 
-# Example:
-# OPENAI_API_KEY=your_secret_key
+# Lexy settings
+# SECRET_KEY=changethis  # change this! you can generate a new one with `openssl rand -hex 32`
+# FIRST_SUPERUSER_EMAIL=lexy@lexy.ai  # change this!
+# FIRST_SUPERUSER_PASSWORD=lexy  # change this!
 # S3_BUCKET=your_s3_bucket_name
+
+# Other secrets
+# OPENAI_API_KEY=your_secret_key
 # GITHUB_TOKEN=your_github_personal_access_token

--- a/Makefile
+++ b/Makefile
@@ -8,3 +8,9 @@ recreate-queues:
 
 inspect-celery:
 	docker exec lexy-celeryworker celery inspect active -t 10.0
+
+update-dev-containers:
+	# rebuild lexyserver and lexyworker
+	docker-compose up --build -d --no-deps lexyserver lexyworker
+	# run DB migrations
+	alembic upgrade head

--- a/docs/docs/contributing.md
+++ b/docs/docs/contributing.md
@@ -1,0 +1,72 @@
+# Contributing to Lexy
+
+This document provides guidance for developers who want to contribute to the Lexy codebase. It includes information on how to set up a development environment, how to run tests, and how to contribute code.
+
+## Contribution Guidelines
+
+Coming soon.
+
+## Developer Notes
+
+This section contains some common development tasks and how to perform them.
+
+### Adding a new migration
+
+To add a new `alembic` migration, first create the migration file.
+
+```bash
+# Create a new migration
+alembic revision --autogenerate -m "Short description of the migration"
+```
+
+Check the migration file in the `alembic/versions` directory and make any necessary changes.
+
+```bash
+# Apply the migration
+alembic upgrade head
+
+# Check the migration status
+alembic current
+```
+
+Add the migration file to version control and open a pull request.
+
+### Updating Docker containers
+
+When you pull changes from the repository, you may need to update your local Docker containers. To rebuild the 
+server and worker containers, and apply database migrations, you can run the following make command:
+
+```bash
+make update-dev-containers
+```
+
+To rebuild the server and worker containers only (without migrations), run the following.
+
+```bash
+docker-compose up --build -d --no-deps lexyserver lexyworker
+```
+
+If for some reason you need to install the new dependencies without rebuilding your containers, run the following:
+
+```bash
+docker exec lexy-server poetry install --no-root -E "lexy_transformers"
+docker exec lexy-celeryworker poetry install --no-root -E "lexy_transformers"
+```
+
+
+### Pip installing into Docker containers
+
+Sometimes you may need to install a new package into the Docker container, since it's much faster than updating 
+`pyproject.toml` and rebuilding. You can do this by running the following:
+
+```bash
+docker exec lexy-server pip install <your_package>
+docker exec lexy-celeryworker pip install <your_package>
+```
+
+If you end up keeping the package, make sure to update `pyproject.toml` and recreate the `poetry.lock` file if needed.
+
+```bash
+poetry add <your_package>
+poetry check
+```

--- a/docs/docs/faq.md
+++ b/docs/docs/faq.md
@@ -11,13 +11,21 @@ cp -n .env.example .env
 
 Then open the `.env` file and add your new environment variable.
 
-```shell title=".env" hl_lines="4"
-# Example .env file
-OPENAI_API_KEY=<secret_api_key>
-S3_BUCKET=<s3_bucket_name>
-NEW_ENV_VAR=<new_env_var_value>
+```shell title=".env" hl_lines="7"
+# Lexy settings
+SECRET_KEY=super_secret_key
+S3_BUCKET=s3_bucket_name
+
+# Other secrets
+OPENAI_API_KEY=your_secret_api_key
+NEW_ENV_VAR=your_new_env_var_value
 ```
 
+
+!!! warning
+
+    Updating the `.env` file will not automatically update the environment variables in your docker containers. You 
+    need to rebuild the containers for the new environment variable to take effect. See below.
 
 You should add environment variables **before** building your docker containers. Or if you have already built your
 containers, you can run the following to rebuild the server and worker containers. 
@@ -32,6 +40,15 @@ Verify that your new environment variable has been added to the server and worke
 docker exec lexy-server env | grep -i NEW_ENV_VAR
 docker exec lexy-celeryworker env | grep -i NEW_ENV_VAR
 ```
+
+??? note "A note about environment variables"
+
+    You can also access the environment variables in your `.env` file using the `lexy.core.config` module. In that
+    case, you don't need to rebuild your containers. 
+
+    Ideally, the variables that are loaded through `lexy.core.config` should be those related to the application's 
+    configuration, whereas user-specific environment variables should be loaded through Python's `os.environ` module.
+
 
 ## Why is Lexy written in Python? Isn't Python slow?
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -1,3 +1,8 @@
+---
+hide:
+    - toc
+---
+
 # Welcome to Lexy
 
 Lexy is a data framework for building AI-powered applications.
@@ -25,3 +30,12 @@ See the [API reference](reference/lexy_api/overview.md) for detailed documentati
 
 The [Python SDK](reference/lexy_py/client.md) is a Python client for Lexy, with detailed documentation.
 
+## Contributing
+
+Check out the [developer notes](contributing.md) for guidance on contributing to the Lexy codebase.
+
+## FAQs
+
+Any questions? Check out the [FAQ](faq.md) for answers to common questions.
+
+If you can't find the answer you're looking for, please [contact us](mailto:hello@lexy.ai).

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -49,7 +49,7 @@ put `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` in your `.env` file.
 
 You'll also need to specify an S3 bucket for file storage (for which your AWS credentials should have full access). 
 You can do so by adding `S3_BUCKET=<name-of-your-S3-bucket>` to your `.env` file, or by updating the value of 
-`s3_bucket` in `lexy/core/config.py`.
+`S3_BUCKET` in `lexy/core/config.py`.
 
 ## Where to find services
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -39,6 +39,7 @@ extra_css:
   - stylesheets/extra.css
 
 markdown_extensions:
+  - admonition
   - pymdownx.details
   - pymdownx.emoji:
       emoji_index: !!python/name:materialx.emoji.twemoji
@@ -112,6 +113,7 @@ nav:
     - Filters: reference/lexy_py/filters.md
     - Index: reference/lexy_py/indexes.md
     - Transformer: reference/lexy_py/transformer.md
+  - Contributing: contributing.md
   - FAQ: faq.md
 
 extra:

--- a/lexy/api/deps.py
+++ b/lexy/api/deps.py
@@ -1,0 +1,57 @@
+from fastapi import Depends, HTTPException, status
+from jose import JWTError, jwt
+from sqlalchemy import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from lexy.core.config import settings
+from lexy.core.security import ALGORITHM, oauth2_scheme, verify_password
+from lexy.db.session import get_session as get_db
+from lexy.models.user import User
+from lexy.schemas.token import TokenData
+
+
+async def get_user_by_email(db: AsyncSession, email: str) -> User:
+    result = await db.execute(select(User).where(User.email == email))
+    user = result.scalars().first()
+    return user
+
+
+async def get_current_user(db: AsyncSession = Depends(get_db), token: str = Depends(oauth2_scheme)) -> User:
+    credentials_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Could not validate credentials",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+    try:
+        payload = jwt.decode(token, settings.SECRET_KEY.get_secret_value(), algorithms=[ALGORITHM])
+        email: str = payload.get("sub")
+        if email is None:
+            raise credentials_exception
+        token_data = TokenData(email=email)
+    except JWTError:
+        raise credentials_exception
+    user = await get_user_by_email(db=db, email=token_data.email)
+    if user is None:
+        raise credentials_exception
+    return user
+
+
+async def get_current_active_user(current_user: User = Depends(get_current_user)):
+    if not current_user.is_active:
+        raise HTTPException(status_code=400, detail="Inactive user")
+    return current_user
+
+
+async def get_current_active_superuser(current_user: User = Depends(get_current_active_user)):
+    if not current_user.is_superuser:
+        raise HTTPException(status_code=403, detail="User does not have enough privileges")
+    return current_user
+
+
+async def authenticate_user(db: AsyncSession, *, email: str, password: str):
+    user = await get_user_by_email(db=db, email=email)
+    if not user:
+        return False
+    if not verify_password(password, user.hashed_password):
+        return False
+    return user

--- a/lexy/api/endpoints/documents.py
+++ b/lexy/api/endpoints/documents.py
@@ -49,7 +49,7 @@ def create_thumbnails_s3(image, sizes, s3_client, s3_bucket, s3_base_path, docum
             "s3_bucket": s3_bucket,
             "s3_key": s3_key,
             "s3_uri": f"s3://{s3_bucket}/{s3_key}",
-            "s3_url": f"https://{settings.s3_bucket}.s3.amazonaws.com/{s3_key}",
+            "s3_url": f"https://{s3_bucket}.s3.amazonaws.com/{s3_key}",
         }
     return thumbnails
 
@@ -156,19 +156,19 @@ async def upload_documents(files: list[UploadFile],
                 # TODO: replace file.filename with the unique document id
                 s3_key = f"collections/{collection_id}/documents/{file.filename}"
                 file.file.seek(0)
-                s3_client.upload_fileobj(file.file, settings.s3_bucket, s3_key)
+                s3_client.upload_fileobj(file.file, settings.S3_BUCKET, s3_key)
 
-                file_dict["s3_bucket"] = settings.s3_bucket
+                file_dict["s3_bucket"] = settings.S3_BUCKET
                 file_dict["s3_key"] = s3_key
-                file_dict["s3_url"] = f"https://{settings.s3_bucket}.s3.amazonaws.com/{s3_key}"
-                file_dict["s3_uri"] = f"s3://{settings.s3_bucket}/{s3_key}"
+                file_dict["s3_url"] = f"https://{settings.S3_BUCKET}.s3.amazonaws.com/{s3_key}"
+                file_dict["s3_uri"] = f"s3://{settings.S3_BUCKET}/{s3_key}"
 
             # generate thumbnails
             if collection.config.get('generate_thumbnails') and collection.config.get('store_files'):
                 thumbnails = create_thumbnails_s3(image=img,
-                                                  sizes=settings.image_thumbnail_sizes,
+                                                  sizes=settings.IMAGE_THUMBNAIL_SIZES,
                                                   s3_client=s3_client,
-                                                  s3_bucket=settings.s3_bucket,
+                                                  s3_bucket=settings.S3_BUCKET,
                                                   s3_base_path=f"collections/{collection_id}/thumbnails",
                                                   document_id=file.filename)
                 file_dict["image"]["thumbnails"] = thumbnails

--- a/lexy/api/endpoints/login.py
+++ b/lexy/api/endpoints/login.py
@@ -1,0 +1,31 @@
+from datetime import timedelta
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordRequestForm
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from lexy.api import deps
+from lexy.core.config import settings
+from lexy.core.security import create_access_token
+from lexy.schemas.token import Token
+
+
+router = APIRouter()
+
+
+@router.post("/login/access-token", response_model=Token)
+async def login_for_access_token(form_data: OAuth2PasswordRequestForm = Depends(),
+                                 db: AsyncSession = Depends(deps.get_db)) -> Token:
+    user = await deps.authenticate_user(db, email=form_data.username, password=form_data.password)
+    if not user:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Incorrect username or password",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    access_token_expires = timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
+    access_token = create_access_token(
+        data={"sub": user.email},
+        expires_delta=access_token_expires
+    )
+    return Token(access_token=access_token, token_type="bearer")

--- a/lexy/api/endpoints/users.py
+++ b/lexy/api/endpoints/users.py
@@ -1,0 +1,98 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from lexy.api.deps import get_current_active_user, get_current_active_superuser, get_db
+from lexy.models.user import User, UserCreate, UserRead, UserUpdate
+
+
+router = APIRouter()
+
+
+@router.get("/users",
+            response_model=list[UserRead],
+            status_code=status.HTTP_200_OK,
+            name="get_users",
+            description="Get all users (superuser only)",
+            dependencies=[Depends(get_current_active_superuser)])
+async def get_users(session: AsyncSession = Depends(get_db)) -> list[UserRead]:
+    result = await session.execute(select(User))
+    users = result.scalars().all()
+    return users
+
+
+@router.get("/users/me",
+            response_model=UserRead,
+            status_code=status.HTTP_200_OK,
+            name="get_user_me",
+            description="Get current user")
+async def get_user_me(current_user: User = Depends(get_current_active_user)) -> UserRead:
+    # TODO: change the next line to `return current_user` after updating SQLModel
+    return UserRead.from_orm(current_user)
+
+
+@router.post("/users",
+             response_model=UserRead,
+             status_code=status.HTTP_201_CREATED,
+             name="create_user",
+             description="Create a new user (superuser only)",
+             dependencies=[Depends(get_current_active_superuser)])
+async def create_user(user: UserCreate, session: AsyncSession = Depends(get_db)) -> UserRead:
+    # check if user already exists
+    result = await session.execute(select(User).where(User.email == user.email))
+    existing_user = result.scalars().first()
+    if existing_user:
+        raise HTTPException(status_code=400, detail="User email is already registered")
+    # create new user
+    new_user = User.create(**user.dict())
+    session.add(new_user)
+    await session.commit()
+    await session.refresh(new_user)
+    return new_user
+
+
+@router.get("/users/{user_id}",
+            response_model=UserRead,
+            status_code=status.HTTP_200_OK,
+            name="get_user",
+            description="Get a specific user (superuser only)",
+            dependencies=[Depends(get_current_active_superuser)])
+async def get_user(user_id: int, session: AsyncSession = Depends(get_db)) -> UserRead:
+    user = await session.get(User, user_id)
+    if user is None:
+        raise HTTPException(status_code=404, detail="User not found")
+    # TODO: change the next line to `return user` after updating SQLModel
+    return UserRead.from_orm(user)
+
+
+@router.delete("/users/{user_id}",
+               status_code=status.HTTP_200_OK,
+               name="delete_user",
+               description="Delete a specific user (superuser only)",
+               dependencies=[Depends(get_current_active_superuser)])
+async def delete_user(user_id: int, session: AsyncSession = Depends(get_db)) -> dict[str, str]:
+    user = await session.get(User, user_id)
+    if user is None:
+        raise HTTPException(status_code=404, detail="User not found")
+    await session.delete(user)
+    await session.commit()
+    return {"detail": "User deleted", "user_id": user_id}
+
+
+@router.patch("/users/{user_id}",
+              response_model=UserRead,
+              status_code=status.HTTP_200_OK,
+              name="update_user",
+              description="Update a specific user (superuser only)",
+              dependencies=[Depends(get_current_active_superuser)])
+async def update_user(user_id: int, user: UserUpdate, session: AsyncSession = Depends(get_db)) -> UserRead:
+    db_user = await session.get(User, user_id)
+    if db_user is None:
+        raise HTTPException(status_code=404, detail="User not found")
+    update_data = user.dict(exclude_unset=True)
+    for field in update_data:
+        setattr(db_user, field, update_data[field])
+    await session.commit()
+    await session.refresh(db_user)
+    # TODO: change the next line to `return db_user` after updating SQLModel
+    return UserRead.from_orm(db_user)

--- a/lexy/api/router.py
+++ b/lexy/api/router.py
@@ -6,7 +6,9 @@ from lexy.api.endpoints import (
     documents,
     indexes,
     index_records,
+    login,
     transformers,
+    users,
     utils
 )
 
@@ -18,5 +20,7 @@ lexy_api.include_router(collections.router, tags=["collections"])
 lexy_api.include_router(documents.router, tags=["documents"])
 lexy_api.include_router(indexes.router, tags=["indexes"])
 lexy_api.include_router(index_records.router, tags=["index_records"])
+lexy_api.include_router(login.router, tags=["login"])
 lexy_api.include_router(transformers.router, tags=["transformers"])
+lexy_api.include_router(users.router, tags=["users"])
 lexy_api.include_router(utils.router, tags=["utils"])

--- a/lexy/core/security.py
+++ b/lexy/core/security.py
@@ -1,0 +1,32 @@
+from datetime import datetime, timedelta, timezone
+
+from fastapi.security import OAuth2PasswordBearer
+from jose import jwt
+from passlib.context import CryptContext
+
+from lexy.core.config import settings
+
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl=f"{settings.API_PREFIX}/login/access-token")
+
+ALGORITHM = "HS256"
+
+
+def get_password_hash(password):
+    return pwd_context.hash(password)
+
+
+def verify_password(plain_password, hashed_password):
+    return pwd_context.verify(plain_password, hashed_password)
+
+
+def create_access_token(data: dict, expires_delta: timedelta | None = None):
+    to_encode = data.copy()
+    if expires_delta:
+        expire = datetime.now(timezone.utc) + expires_delta
+    else:
+        expire = datetime.now(timezone.utc) + timedelta(minutes=15)
+    to_encode.update({"exp": expire})
+    encoded_jwt = jwt.encode(to_encode, settings.SECRET_KEY.get_secret_value(), algorithm=ALGORITHM)
+    return encoded_jwt

--- a/lexy/db/session.py
+++ b/lexy/db/session.py
@@ -7,12 +7,12 @@ from lexy.core.config import settings
 
 sync_engine = create_engine(
     url=settings.sync_database_url,
-    echo=settings.db_echo_log
+    echo=settings.DB_ECHO_LOG
 )
 
 async_engine = AsyncEngine(create_engine(
     url=settings.async_database_url,
-    echo=settings.db_echo_log,
+    echo=settings.DB_ECHO_LOG,
     future=True
 ))
 

--- a/lexy/indexes.py
+++ b/lexy/indexes.py
@@ -156,7 +156,7 @@ class IndexManager(object):
         indexes = self.get_indexes()
         for index in indexes:
             if self.table_exists(index.index_table_name):
-                logger.warning(f"create_index_models -- Index table {index.index_table_name} already exists.")
+                logger.info(f"create_index_models -- Index table {index.index_table_name} already exists.")
             self.create_index_model(index)
 
     def create_index_model(self, index: Index):

--- a/lexy/main.py
+++ b/lexy/main.py
@@ -15,14 +15,14 @@ for module in settings.app_transformer_imports:
 
 def create_app() -> FastAPI:
     fastapi_app = FastAPI(
-        title=settings.title,
-        version=settings.version,
-        description=settings.description,
-        openapi_prefix=settings.openapi_prefix,
-        docs_url=settings.docs_url,
-        openapi_url=settings.openapi_url
+        title=settings.TITLE,
+        version=settings.VERSION,
+        description=settings.DESCRIPTION,
+        openapi_prefix=settings.OPENAPI_PREFIX,
+        docs_url=settings.DOCS_URL,
+        openapi_url=settings.OPENAPI_URL
     )
-    fastapi_app.include_router(lexy_api, prefix=settings.api_prefix)
+    fastapi_app.include_router(lexy_api, prefix=settings.API_PREFIX)
     return fastapi_app
 
 

--- a/lexy/models/__init__.py
+++ b/lexy/models/__init__.py
@@ -4,3 +4,4 @@ from lexy.models.document import Document, DocumentCreate, DocumentUpdate
 from lexy.models.index import Index, IndexCreate, IndexUpdate
 from lexy.models.index_record import IndexRecordBase, IndexRecordBaseTable, IndexRecordCreate, IndexRecordUpdate
 from lexy.models.transformer import Transformer, TransformerCreate, TransformerUpdate
+from lexy.models.user import User, UserCreate, UserUpdate

--- a/lexy/models/collection.py
+++ b/lexy/models/collection.py
@@ -21,7 +21,7 @@ class CollectionBase(SQLModel):
         regex=r"^[A-Za-z0-9_-]+$"
     )
     description: Optional[str] = None
-    config: Optional[dict[str, Any]] = Field(sa_column=Column(JSONB), default=settings.collection_default_config)
+    config: Optional[dict[str, Any]] = Field(sa_column=Column(JSONB), default=settings.COLLECTION_DEFAULT_CONFIG)
 
 
 class Collection(CollectionBase, table=True):

--- a/lexy/models/user.py
+++ b/lexy/models/user.py
@@ -1,0 +1,54 @@
+from datetime import datetime
+from typing import Optional
+
+from pydantic import EmailStr
+from sqlalchemy import Column, DateTime, func
+from sqlmodel import Field, SQLModel
+
+from lexy.core.security import get_password_hash
+
+
+class UserBase(SQLModel):
+    email: EmailStr = Field(index=True, nullable=False, unique=True)
+    full_name: Optional[str] = None
+
+
+class User(UserBase, table=True):
+    __tablename__ = "users"
+    user_id: int = Field(default=None, primary_key=True, index=True)
+    hashed_password: str
+    is_active: bool = Field(default=True)
+    is_superuser: bool = Field(default=False)
+    created_at: datetime = Field(
+        sa_column=Column(DateTime(timezone=True), nullable=False, server_default=func.now()),
+    )
+    updated_at: datetime = Field(
+        sa_column=Column(DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now()),
+    )
+
+    @classmethod
+    def create(cls, email: str, password: str, **kwargs):
+        hashed_password = get_password_hash(password)
+        return cls(email=email, hashed_password=hashed_password, **kwargs)
+
+
+# Properties to receive via API on creation
+class UserCreate(UserBase):
+    email: EmailStr
+    password: str
+
+
+# Additional properties to return via API
+class UserRead(UserBase):
+    user_id: int
+    is_active: bool
+    is_superuser: bool
+    created_at: datetime
+    updated_at: datetime
+
+
+# Properties to receive via API on update
+class UserUpdate(UserBase):
+    full_name: Optional[str] = None
+    is_active: Optional[bool] = None
+    is_superuser: Optional[bool] = None

--- a/lexy/schemas/token.py
+++ b/lexy/schemas/token.py
@@ -1,0 +1,10 @@
+from pydantic import BaseModel
+
+
+class Token(BaseModel):
+    access_token: str
+    token_type: str
+
+
+class TokenData(BaseModel):
+    email: str | None = None

--- a/lexy/storage/client.py
+++ b/lexy/storage/client.py
@@ -10,11 +10,11 @@ if TYPE_CHECKING:
 
 async def get_s3_client() -> boto3.client:
     client_kwargs = {}
-    if settings.aws_access_key_id and settings.aws_secret_access_key:
-        client_kwargs["aws_access_key_id"] = settings.aws_access_key_id
-        client_kwargs["aws_secret_access_key"] = settings.aws_secret_access_key
-    if settings.aws_region:
-        client_kwargs["region_name"] = settings.aws_region
+    if settings.AWS_ACCESS_KEY_ID and settings.AWS_SECRET_ACCESS_KEY:
+        client_kwargs["aws_access_key_id"] = settings.AWS_ACCESS_KEY_ID
+        client_kwargs["aws_secret_access_key"] = settings.AWS_SECRET_ACCESS_KEY.get_secret_value()
+    if settings.AWS_REGION:
+        client_kwargs["region_name"] = settings.AWS_REGION
     return boto3.client('s3', **client_kwargs)
 
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -172,6 +172,46 @@ files = [
 dev = ["freezegun (>=1.0,<2.0)", "pytest (>=6.0)", "pytest-cov"]
 
 [[package]]
+name = "bcrypt"
+version = "4.1.2"
+description = "Modern password hashing for your software and your servers"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "bcrypt-4.1.2-cp37-abi3-macosx_10_12_universal2.whl", hash = "sha256:ac621c093edb28200728a9cca214d7e838529e557027ef0581685909acd28b5e"},
+    {file = "bcrypt-4.1.2-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ea505c97a5c465ab8c3ba75c0805a102ce526695cd6818c6de3b1a38f6f60da1"},
+    {file = "bcrypt-4.1.2-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:57fa9442758da926ed33a91644649d3e340a71e2d0a5a8de064fb621fd5a3326"},
+    {file = "bcrypt-4.1.2-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:eb3bd3321517916696233b5e0c67fd7d6281f0ef48e66812db35fc963a422a1c"},
+    {file = "bcrypt-4.1.2-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:6cad43d8c63f34b26aef462b6f5e44fdcf9860b723d2453b5d391258c4c8e966"},
+    {file = "bcrypt-4.1.2-cp37-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:44290ccc827d3a24604f2c8bcd00d0da349e336e6503656cb8192133e27335e2"},
+    {file = "bcrypt-4.1.2-cp37-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:732b3920a08eacf12f93e6b04ea276c489f1c8fb49344f564cca2adb663b3e4c"},
+    {file = "bcrypt-4.1.2-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1c28973decf4e0e69cee78c68e30a523be441972c826703bb93099868a8ff5b5"},
+    {file = "bcrypt-4.1.2-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b8df79979c5bae07f1db22dcc49cc5bccf08a0380ca5c6f391cbb5790355c0b0"},
+    {file = "bcrypt-4.1.2-cp37-abi3-win32.whl", hash = "sha256:fbe188b878313d01b7718390f31528be4010fed1faa798c5a1d0469c9c48c369"},
+    {file = "bcrypt-4.1.2-cp37-abi3-win_amd64.whl", hash = "sha256:9800ae5bd5077b13725e2e3934aa3c9c37e49d3ea3d06318010aa40f54c63551"},
+    {file = "bcrypt-4.1.2-cp39-abi3-macosx_10_12_universal2.whl", hash = "sha256:71b8be82bc46cedd61a9f4ccb6c1a493211d031415a34adde3669ee1b0afbb63"},
+    {file = "bcrypt-4.1.2-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:68e3c6642077b0c8092580c819c1684161262b2e30c4f45deb000c38947bf483"},
+    {file = "bcrypt-4.1.2-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:387e7e1af9a4dd636b9505a465032f2f5cb8e61ba1120e79a0e1cd0b512f3dfc"},
+    {file = "bcrypt-4.1.2-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:f70d9c61f9c4ca7d57f3bfe88a5ccf62546ffbadf3681bb1e268d9d2e41c91a7"},
+    {file = "bcrypt-4.1.2-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2a298db2a8ab20056120b45e86c00a0a5eb50ec4075b6142db35f593b97cb3fb"},
+    {file = "bcrypt-4.1.2-cp39-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:ba55e40de38a24e2d78d34c2d36d6e864f93e0d79d0b6ce915e4335aa81d01b1"},
+    {file = "bcrypt-4.1.2-cp39-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:3566a88234e8de2ccae31968127b0ecccbb4cddb629da744165db72b58d88ca4"},
+    {file = "bcrypt-4.1.2-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b90e216dc36864ae7132cb151ffe95155a37a14e0de3a8f64b49655dd959ff9c"},
+    {file = "bcrypt-4.1.2-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:69057b9fc5093ea1ab00dd24ede891f3e5e65bee040395fb1e66ee196f9c9b4a"},
+    {file = "bcrypt-4.1.2-cp39-abi3-win32.whl", hash = "sha256:02d9ef8915f72dd6daaef40e0baeef8a017ce624369f09754baf32bb32dba25f"},
+    {file = "bcrypt-4.1.2-cp39-abi3-win_amd64.whl", hash = "sha256:be3ab1071662f6065899fe08428e45c16aa36e28bc42921c4901a191fda6ee42"},
+    {file = "bcrypt-4.1.2-pp310-pypy310_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:d75fc8cd0ba23f97bae88a6ec04e9e5351ff3c6ad06f38fe32ba50cbd0d11946"},
+    {file = "bcrypt-4.1.2-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:a97e07e83e3262599434816f631cc4c7ca2aa8e9c072c1b1a7fec2ae809a1d2d"},
+    {file = "bcrypt-4.1.2-pp39-pypy39_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:e51c42750b7585cee7892c2614be0d14107fad9581d1738d954a262556dd1aab"},
+    {file = "bcrypt-4.1.2-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:ba4e4cc26610581a6329b3937e02d319f5ad4b85b074846bf4fef8a8cf51e7bb"},
+    {file = "bcrypt-4.1.2.tar.gz", hash = "sha256:33313a1200a3ae90b75587ceac502b048b840fc69e7f7a0905b5f87fac7a1258"},
+]
+
+[package.extras]
+tests = ["pytest (>=3.2.1,!=3.3.0)"]
+typecheck = ["mypy"]
+
+[[package]]
 name = "beautifulsoup4"
 version = "4.12.3"
 description = "Screen-scraping library"
@@ -306,6 +346,70 @@ files = [
     {file = "certifi-2023.11.17-py3-none-any.whl", hash = "sha256:e036ab49d5b79556f99cfc2d9320b34cfbe5be05c5871b51de9329f0603b0474"},
     {file = "certifi-2023.11.17.tar.gz", hash = "sha256:9b469f3a900bf28dc19b8cfbf8019bf47f7fdd1a65a1d4ffb98fc14166beb4d1"},
 ]
+
+[[package]]
+name = "cffi"
+version = "1.16.0"
+description = "Foreign Function Interface for Python calling C code."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "cffi-1.16.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:6b3d6606d369fc1da4fd8c357d026317fbb9c9b75d36dc16e90e84c26854b088"},
+    {file = "cffi-1.16.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ac0f5edd2360eea2f1daa9e26a41db02dd4b0451b48f7c318e217ee092a213e9"},
+    {file = "cffi-1.16.0-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7e61e3e4fa664a8588aa25c883eab612a188c725755afff6289454d6362b9673"},
+    {file = "cffi-1.16.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a72e8961a86d19bdb45851d8f1f08b041ea37d2bd8d4fd19903bc3083d80c896"},
+    {file = "cffi-1.16.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5b50bf3f55561dac5438f8e70bfcdfd74543fd60df5fa5f62d94e5867deca684"},
+    {file = "cffi-1.16.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7651c50c8c5ef7bdb41108b7b8c5a83013bfaa8a935590c5d74627c047a583c7"},
+    {file = "cffi-1.16.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e4108df7fe9b707191e55f33efbcb2d81928e10cea45527879a4749cbe472614"},
+    {file = "cffi-1.16.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:32c68ef735dbe5857c810328cb2481e24722a59a2003018885514d4c09af9743"},
+    {file = "cffi-1.16.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:673739cb539f8cdaa07d92d02efa93c9ccf87e345b9a0b556e3ecc666718468d"},
+    {file = "cffi-1.16.0-cp310-cp310-win32.whl", hash = "sha256:9f90389693731ff1f659e55c7d1640e2ec43ff725cc61b04b2f9c6d8d017df6a"},
+    {file = "cffi-1.16.0-cp310-cp310-win_amd64.whl", hash = "sha256:e6024675e67af929088fda399b2094574609396b1decb609c55fa58b028a32a1"},
+    {file = "cffi-1.16.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b84834d0cf97e7d27dd5b7f3aca7b6e9263c56308ab9dc8aae9784abb774d404"},
+    {file = "cffi-1.16.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1b8ebc27c014c59692bb2664c7d13ce7a6e9a629be20e54e7271fa696ff2b417"},
+    {file = "cffi-1.16.0-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ee07e47c12890ef248766a6e55bd38ebfb2bb8edd4142d56db91b21ea68b7627"},
+    {file = "cffi-1.16.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d8a9d3ebe49f084ad71f9269834ceccbf398253c9fac910c4fd7053ff1386936"},
+    {file = "cffi-1.16.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e70f54f1796669ef691ca07d046cd81a29cb4deb1e5f942003f401c0c4a2695d"},
+    {file = "cffi-1.16.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5bf44d66cdf9e893637896c7faa22298baebcd18d1ddb6d2626a6e39793a1d56"},
+    {file = "cffi-1.16.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7b78010e7b97fef4bee1e896df8a4bbb6712b7f05b7ef630f9d1da00f6444d2e"},
+    {file = "cffi-1.16.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:c6a164aa47843fb1b01e941d385aab7215563bb8816d80ff3a363a9f8448a8dc"},
+    {file = "cffi-1.16.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:e09f3ff613345df5e8c3667da1d918f9149bd623cd9070c983c013792a9a62eb"},
+    {file = "cffi-1.16.0-cp311-cp311-win32.whl", hash = "sha256:2c56b361916f390cd758a57f2e16233eb4f64bcbeee88a4881ea90fca14dc6ab"},
+    {file = "cffi-1.16.0-cp311-cp311-win_amd64.whl", hash = "sha256:db8e577c19c0fda0beb7e0d4e09e0ba74b1e4c092e0e40bfa12fe05b6f6d75ba"},
+    {file = "cffi-1.16.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:fa3a0128b152627161ce47201262d3140edb5a5c3da88d73a1b790a959126956"},
+    {file = "cffi-1.16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:68e7c44931cc171c54ccb702482e9fc723192e88d25a0e133edd7aff8fcd1f6e"},
+    {file = "cffi-1.16.0-cp312-cp312-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:abd808f9c129ba2beda4cfc53bde801e5bcf9d6e0f22f095e45327c038bfe68e"},
+    {file = "cffi-1.16.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:88e2b3c14bdb32e440be531ade29d3c50a1a59cd4e51b1dd8b0865c54ea5d2e2"},
+    {file = "cffi-1.16.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fcc8eb6d5902bb1cf6dc4f187ee3ea80a1eba0a89aba40a5cb20a5087d961357"},
+    {file = "cffi-1.16.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b7be2d771cdba2942e13215c4e340bfd76398e9227ad10402a8767ab1865d2e6"},
+    {file = "cffi-1.16.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e715596e683d2ce000574bae5d07bd522c781a822866c20495e52520564f0969"},
+    {file = "cffi-1.16.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:2d92b25dbf6cae33f65005baf472d2c245c050b1ce709cc4588cdcdd5495b520"},
+    {file = "cffi-1.16.0-cp312-cp312-win32.whl", hash = "sha256:b2ca4e77f9f47c55c194982e10f058db063937845bb2b7a86c84a6cfe0aefa8b"},
+    {file = "cffi-1.16.0-cp312-cp312-win_amd64.whl", hash = "sha256:68678abf380b42ce21a5f2abde8efee05c114c2fdb2e9eef2efdb0257fba1235"},
+    {file = "cffi-1.16.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:0c9ef6ff37e974b73c25eecc13952c55bceed9112be2d9d938ded8e856138bcc"},
+    {file = "cffi-1.16.0-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a09582f178759ee8128d9270cd1344154fd473bb77d94ce0aeb2a93ebf0feaf0"},
+    {file = "cffi-1.16.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e760191dd42581e023a68b758769e2da259b5d52e3103c6060ddc02c9edb8d7b"},
+    {file = "cffi-1.16.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:80876338e19c951fdfed6198e70bc88f1c9758b94578d5a7c4c91a87af3cf31c"},
+    {file = "cffi-1.16.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a6a14b17d7e17fa0d207ac08642c8820f84f25ce17a442fd15e27ea18d67c59b"},
+    {file = "cffi-1.16.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6602bc8dc6f3a9e02b6c22c4fc1e47aa50f8f8e6d3f78a5e16ac33ef5fefa324"},
+    {file = "cffi-1.16.0-cp38-cp38-win32.whl", hash = "sha256:131fd094d1065b19540c3d72594260f118b231090295d8c34e19a7bbcf2e860a"},
+    {file = "cffi-1.16.0-cp38-cp38-win_amd64.whl", hash = "sha256:31d13b0f99e0836b7ff893d37af07366ebc90b678b6664c955b54561fc36ef36"},
+    {file = "cffi-1.16.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:582215a0e9adbe0e379761260553ba11c58943e4bbe9c36430c4ca6ac74b15ed"},
+    {file = "cffi-1.16.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:b29ebffcf550f9da55bec9e02ad430c992a87e5f512cd63388abb76f1036d8d2"},
+    {file = "cffi-1.16.0-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:dc9b18bf40cc75f66f40a7379f6a9513244fe33c0e8aa72e2d56b0196a7ef872"},
+    {file = "cffi-1.16.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9cb4a35b3642fc5c005a6755a5d17c6c8b6bcb6981baf81cea8bfbc8903e8ba8"},
+    {file = "cffi-1.16.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b86851a328eedc692acf81fb05444bdf1891747c25af7529e39ddafaf68a4f3f"},
+    {file = "cffi-1.16.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c0f31130ebc2d37cdd8e44605fb5fa7ad59049298b3f745c74fa74c62fbfcfc4"},
+    {file = "cffi-1.16.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8f8e709127c6c77446a8c0a8c8bf3c8ee706a06cd44b1e827c3e6a2ee6b8c098"},
+    {file = "cffi-1.16.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:748dcd1e3d3d7cd5443ef03ce8685043294ad6bd7c02a38d1bd367cfd968e000"},
+    {file = "cffi-1.16.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:8895613bcc094d4a1b2dbe179d88d7fb4a15cee43c052e8885783fac397d91fe"},
+    {file = "cffi-1.16.0-cp39-cp39-win32.whl", hash = "sha256:ed86a35631f7bfbb28e108dd96773b9d5a6ce4811cf6ea468bb6a359b256b1e4"},
+    {file = "cffi-1.16.0-cp39-cp39-win_amd64.whl", hash = "sha256:3686dffb02459559c74dd3d81748269ffb0eb027c39a6fc99502de37d501faa8"},
+    {file = "cffi-1.16.0.tar.gz", hash = "sha256:bcb3ef43e58665bbda2fb198698fcae6776483e0c4a631aa5647806c25e02cc0"},
+]
+
+[package.dependencies]
+pycparser = "*"
 
 [[package]]
 name = "charset-normalizer"
@@ -481,6 +585,60 @@ files = [
 ]
 
 [[package]]
+name = "cryptography"
+version = "42.0.2"
+description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "cryptography-42.0.2-cp37-abi3-macosx_10_12_universal2.whl", hash = "sha256:701171f825dcab90969596ce2af253143b93b08f1a716d4b2a9d2db5084ef7be"},
+    {file = "cryptography-42.0.2-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:61321672b3ac7aade25c40449ccedbc6db72c7f5f0fdf34def5e2f8b51ca530d"},
+    {file = "cryptography-42.0.2-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ea2c3ffb662fec8bbbfce5602e2c159ff097a4631d96235fcf0fb00e59e3ece4"},
+    {file = "cryptography-42.0.2-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3b15c678f27d66d247132cbf13df2f75255627bcc9b6a570f7d2fd08e8c081d2"},
+    {file = "cryptography-42.0.2-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:8e88bb9eafbf6a4014d55fb222e7360eef53e613215085e65a13290577394529"},
+    {file = "cryptography-42.0.2-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:a047682d324ba56e61b7ea7c7299d51e61fd3bca7dad2ccc39b72bd0118d60a1"},
+    {file = "cryptography-42.0.2-cp37-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:36d4b7c4be6411f58f60d9ce555a73df8406d484ba12a63549c88bd64f7967f1"},
+    {file = "cryptography-42.0.2-cp37-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:a00aee5d1b6c20620161984f8ab2ab69134466c51f58c052c11b076715e72929"},
+    {file = "cryptography-42.0.2-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b97fe7d7991c25e6a31e5d5e795986b18fbbb3107b873d5f3ae6dc9a103278e9"},
+    {file = "cryptography-42.0.2-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5fa82a26f92871eca593b53359c12ad7949772462f887c35edaf36f87953c0e2"},
+    {file = "cryptography-42.0.2-cp37-abi3-win32.whl", hash = "sha256:4b063d3413f853e056161eb0c7724822a9740ad3caa24b8424d776cebf98e7ee"},
+    {file = "cryptography-42.0.2-cp37-abi3-win_amd64.whl", hash = "sha256:841ec8af7a8491ac76ec5a9522226e287187a3107e12b7d686ad354bb78facee"},
+    {file = "cryptography-42.0.2-cp39-abi3-macosx_10_12_universal2.whl", hash = "sha256:55d1580e2d7e17f45d19d3b12098e352f3a37fe86d380bf45846ef257054b242"},
+    {file = "cryptography-42.0.2-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:28cb2c41f131a5758d6ba6a0504150d644054fd9f3203a1e8e8d7ac3aea7f73a"},
+    {file = "cryptography-42.0.2-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b9097a208875fc7bbeb1286d0125d90bdfed961f61f214d3f5be62cd4ed8a446"},
+    {file = "cryptography-42.0.2-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:44c95c0e96b3cb628e8452ec060413a49002a247b2b9938989e23a2c8291fc90"},
+    {file = "cryptography-42.0.2-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2f9f14185962e6a04ab32d1abe34eae8a9001569ee4edb64d2304bf0d65c53f3"},
+    {file = "cryptography-42.0.2-cp39-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:09a77e5b2e8ca732a19a90c5bca2d124621a1edb5438c5daa2d2738bfeb02589"},
+    {file = "cryptography-42.0.2-cp39-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:ad28cff53f60d99a928dfcf1e861e0b2ceb2bc1f08a074fdd601b314e1cc9e0a"},
+    {file = "cryptography-42.0.2-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:130c0f77022b2b9c99d8cebcdd834d81705f61c68e91ddd614ce74c657f8b3ea"},
+    {file = "cryptography-42.0.2-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:fa3dec4ba8fb6e662770b74f62f1a0c7d4e37e25b58b2bf2c1be4c95372b4a33"},
+    {file = "cryptography-42.0.2-cp39-abi3-win32.whl", hash = "sha256:3dbd37e14ce795b4af61b89b037d4bc157f2cb23e676fa16932185a04dfbf635"},
+    {file = "cryptography-42.0.2-cp39-abi3-win_amd64.whl", hash = "sha256:8a06641fb07d4e8f6c7dda4fc3f8871d327803ab6542e33831c7ccfdcb4d0ad6"},
+    {file = "cryptography-42.0.2-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:087887e55e0b9c8724cf05361357875adb5c20dec27e5816b653492980d20380"},
+    {file = "cryptography-42.0.2-pp310-pypy310_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:a7ef8dd0bf2e1d0a27042b231a3baac6883cdd5557036f5e8df7139255feaac6"},
+    {file = "cryptography-42.0.2-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:4383b47f45b14459cab66048d384614019965ba6c1a1a141f11b5a551cace1b2"},
+    {file = "cryptography-42.0.2-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:fbeb725c9dc799a574518109336acccaf1303c30d45c075c665c0793c2f79a7f"},
+    {file = "cryptography-42.0.2-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:320948ab49883557a256eab46149df79435a22d2fefd6a66fe6946f1b9d9d008"},
+    {file = "cryptography-42.0.2-pp39-pypy39_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:5ef9bc3d046ce83c4bbf4c25e1e0547b9c441c01d30922d812e887dc5f125c12"},
+    {file = "cryptography-42.0.2-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:52ed9ebf8ac602385126c9a2fe951db36f2cb0c2538d22971487f89d0de4065a"},
+    {file = "cryptography-42.0.2-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:141e2aa5ba100d3788c0ad7919b288f89d1fe015878b9659b307c9ef867d3a65"},
+    {file = "cryptography-42.0.2.tar.gz", hash = "sha256:e0ec52ba3c7f1b7d813cd52649a5b3ef1fc0d433219dc8c93827c57eab6cf888"},
+]
+
+[package.dependencies]
+cffi = {version = ">=1.12", markers = "platform_python_implementation != \"PyPy\""}
+
+[package.extras]
+docs = ["sphinx (>=5.3.0)", "sphinx-rtd-theme (>=1.1.1)"]
+docstest = ["pyenchant (>=1.6.11)", "readme-renderer", "sphinxcontrib-spelling (>=4.0.1)"]
+nox = ["nox"]
+pep8test = ["check-sdist", "click", "mypy", "ruff"]
+sdist = ["build"]
+ssh = ["bcrypt (>=3.1.5)"]
+test = ["certifi", "pretend", "pytest (>=6.2.0)", "pytest-benchmark", "pytest-cov", "pytest-xdist"]
+test-randomorder = ["pytest-randomly"]
+
+[[package]]
 name = "distro"
 version = "1.9.0"
 description = "Distro - an OS platform information API"
@@ -492,6 +650,26 @@ files = [
 ]
 
 [[package]]
+name = "dnspython"
+version = "2.5.0"
+description = "DNS toolkit"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "dnspython-2.5.0-py3-none-any.whl", hash = "sha256:6facdf76b73c742ccf2d07add296f178e629da60be23ce4b0a9c927b1e02c3a6"},
+    {file = "dnspython-2.5.0.tar.gz", hash = "sha256:a0034815a59ba9ae888946be7ccca8f7c157b286f8455b379c692efb51022a15"},
+]
+
+[package.extras]
+dev = ["black (>=23.1.0)", "coverage (>=7.0)", "flake8 (>=5.0.3)", "mypy (>=1.0.1)", "pylint (>=2.7)", "pytest (>=6.2.5)", "pytest-cov (>=3.0.0)", "sphinx (>=7.0.0)", "twine (>=4.0.0)", "wheel (>=0.41.0)"]
+dnssec = ["cryptography (>=41)"]
+doh = ["h2 (>=4.1.0)", "httpcore (>=0.17.3)", "httpx (>=0.25.1)"]
+doq = ["aioquic (>=0.9.20)"]
+idna = ["idna (>=2.1)"]
+trio = ["trio (>=0.14)"]
+wmi = ["wmi (>=1.5.1)"]
+
+[[package]]
 name = "docutils"
 version = "0.16"
 description = "Docutils -- Python Documentation Utilities"
@@ -501,6 +679,39 @@ files = [
     {file = "docutils-0.16-py2.py3-none-any.whl", hash = "sha256:0c5b78adfbf7762415433f5515cd5c9e762339e23369dbe8000d84a4bf4ab3af"},
     {file = "docutils-0.16.tar.gz", hash = "sha256:c2de3a60e9e7d07be26b7f2b00ca0309c207e06c100f9cc2a94931fc75a478fc"},
 ]
+
+[[package]]
+name = "ecdsa"
+version = "0.18.0"
+description = "ECDSA cryptographic signature library (pure python)"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+files = [
+    {file = "ecdsa-0.18.0-py2.py3-none-any.whl", hash = "sha256:80600258e7ed2f16b9aa1d7c295bd70194109ad5a30fdee0eaeefef1d4c559dd"},
+    {file = "ecdsa-0.18.0.tar.gz", hash = "sha256:190348041559e21b22a1d65cee485282ca11a6f81d503fddb84d5017e9ed1e49"},
+]
+
+[package.dependencies]
+six = ">=1.9.0"
+
+[package.extras]
+gmpy = ["gmpy"]
+gmpy2 = ["gmpy2"]
+
+[[package]]
+name = "email-validator"
+version = "2.1.0.post1"
+description = "A robust email address syntax and deliverability validation library."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "email_validator-2.1.0.post1-py3-none-any.whl", hash = "sha256:c973053efbeddfef924dc0bd93f6e77a1ea7ee0fce935aea7103c7a3d6d2d637"},
+    {file = "email_validator-2.1.0.post1.tar.gz", hash = "sha256:a4b0bd1cf55f073b924258d19321b1f3aa74b4b5a71a42c305575dba920e1a44"},
+]
+
+[package.dependencies]
+dnspython = ">=2.0.0"
+idna = ">=2.0.0"
 
 [[package]]
 name = "exceptiongroup"
@@ -1494,6 +1705,26 @@ files = [
 ]
 
 [[package]]
+name = "passlib"
+version = "1.7.4"
+description = "comprehensive password hashing framework supporting over 30 schemes"
+optional = false
+python-versions = "*"
+files = [
+    {file = "passlib-1.7.4-py2.py3-none-any.whl", hash = "sha256:aa6bca462b8d8bda89c70b382f0c298a20b5560af6cbfa2dce410c0a2fb669f1"},
+    {file = "passlib-1.7.4.tar.gz", hash = "sha256:defd50f72b65c5402ab2c573830a6978e5f202ad0d984793c8dde2c4152ebe04"},
+]
+
+[package.dependencies]
+bcrypt = {version = ">=3.1.0", optional = true, markers = "extra == \"bcrypt\""}
+
+[package.extras]
+argon2 = ["argon2-cffi (>=18.2.0)"]
+bcrypt = ["bcrypt (>=3.1.0)"]
+build-docs = ["cloud-sptheme (>=1.10.1)", "sphinx (>=1.6)", "sphinxcontrib-fulltoc (>=1.2.0)"]
+totp = ["cryptography"]
+
+[[package]]
 name = "pathspec"
 version = "0.12.1"
 description = "Utility library for gitignore style pattern matching of file paths."
@@ -1768,6 +1999,17 @@ files = [
 ]
 
 [[package]]
+name = "pycparser"
+version = "2.21"
+description = "C parser in Python"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+files = [
+    {file = "pycparser-2.21-py2.py3-none-any.whl", hash = "sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9"},
+    {file = "pycparser-2.21.tar.gz", hash = "sha256:e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206"},
+]
+
+[[package]]
 name = "pycryptodome"
 version = "3.20.0"
 description = "Cryptographic library for Python"
@@ -1854,6 +2096,8 @@ files = [
 ]
 
 [package.dependencies]
+email-validator = {version = ">=1.0.3", optional = true, markers = "extra == \"email\""}
+python-dotenv = {version = ">=0.10.4", optional = true, markers = "extra == \"dotenv\""}
 typing-extensions = ">=4.2.0"
 
 [package.extras]
@@ -1981,6 +2225,42 @@ files = [
 
 [package.dependencies]
 six = ">=1.5"
+
+[[package]]
+name = "python-dotenv"
+version = "1.0.1"
+description = "Read key-value pairs from a .env file and set them as environment variables"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "python-dotenv-1.0.1.tar.gz", hash = "sha256:e324ee90a023d808f1959c46bcbc04446a10ced277783dc6ee09987c37ec10ca"},
+    {file = "python_dotenv-1.0.1-py3-none-any.whl", hash = "sha256:f7b63ef50f1b690dddf550d03497b66d609393b40b564ed0d674909a68ebf16a"},
+]
+
+[package.extras]
+cli = ["click (>=5.0)"]
+
+[[package]]
+name = "python-jose"
+version = "3.3.0"
+description = "JOSE implementation in Python"
+optional = false
+python-versions = "*"
+files = [
+    {file = "python-jose-3.3.0.tar.gz", hash = "sha256:55779b5e6ad599c6336191246e95eb2293a9ddebd555f796a65f838f07e5d78a"},
+    {file = "python_jose-3.3.0-py2.py3-none-any.whl", hash = "sha256:9b1376b023f8b298536eedd47ae1089bcdb848f1535ab30555cd92002d78923a"},
+]
+
+[package.dependencies]
+cryptography = {version = ">=3.4.0", optional = true, markers = "extra == \"cryptography\""}
+ecdsa = "!=0.15"
+pyasn1 = "*"
+rsa = "*"
+
+[package.extras]
+cryptography = ["cryptography (>=3.4.0)"]
+pycrypto = ["pyasn1", "pycrypto (>=2.6.0,<2.7.0)"]
+pycryptodome = ["pyasn1", "pycryptodome (>=3.3.1,<4.0.0)"]
 
 [[package]]
 name = "python-multipart"
@@ -3230,4 +3510,4 @@ lexy-transformers = ["openai", "sentence-transformers", "transformers"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "5845f10457043db8f0b521f5ecaec484082de16c521ba4065f71ad972ea72f95"
+content-hash = "cefff0d51bfcee4470ef38dc68728e2c38e39a709c2de617f5d268bb7b3125bc"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,9 @@ readme = "README.md"
 python = "^3.10"
 fastapi = "^0.103.0"
 sqlmodel = "^0.0.11"
+pydantic = { version = "^1.10.0", extras = ["email", "dotenv"] }
+python-jose = {version = "^3.3.0", extras = ["cryptography"]}
+passlib = {version = "^1.7.4", extras = ["bcrypt"]}
 psycopg2-binary = "^2.9.7"
 asyncpg = "^0.28.0"
 uvicorn = "^0.23.2"


### PR DESCRIPTION
# What

Added a User model with OAuth2. See the Miscellaneous section below on updating existing containers.
- User model definitions
- API endpoints for User model (`lexy.api.endpoints.users`)
- API endpoints for authentication (`lexy.api.endpoints.login`)
- Superuser is added to the database during initialization
- New packages to enable auth and user settings
  + pydantic[email], pydantic[dotenv], python-jose[cryptography], passlib[bcrypt]
- Refactored `lexy.core.config` module to use `pydantic.BaseSettings` class
- Additional documentation

Note: This PR does **not** include any auth on the client. Still need to create the ability to stamp API keys and use them as headers for `LexyClient`.


# Why

We need a User model.


# Test plan

- [x] Run `pytest sdk-python` in terminal
- [x] Run all cells in `examples/tests.ipynb` and verify that there are no errors
- [x] Run all cells in `examples/tutorial.ipynb` and verify that the tutorial works as expected
- [ ] Run all cells in `examples/images.ipynb` and verify that the tutorial works as expected


# Miscellaneous

This PR contains some new packages. The easiest thing to do is nuke and rebuild your containers. If you don't want to do so, you can avoid it by running the following.

```shell
# install new dependencies in virtual env
source venv/bin/activate
poetry install --no-root --with test,docs,dev -E "lexy_transformers"

# rebuild docker containers and apply migrations
make update-dev-containers
```