### PR TITLE
Improved testing

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,7 @@
 
 # Test plan
 
-- [ ] Run `pytest sdk-python`
+- [ ] Run `make run-tests` and verify that all tests pass
 - [ ] Run `examples/tests.ipynb` and verify that there are no errors
 - [ ] Run `examples/tutorial.ipynb` and verify that the tutorial works as expected
 - [ ] Run `examples/images.ipynb` and verify that the tutorial works as expected

--- a/Makefile
+++ b/Makefile
@@ -14,3 +14,7 @@ update-dev-containers:
 	docker-compose up --build -d --no-deps lexyserver lexyworker
 	# run DB migrations
 	alembic upgrade head
+
+run-tests:
+	pytest lexy_tests
+	pytest sdk-python

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,6 +18,7 @@ services:
       - POSTGRES_PASSWORD=postgres
       - POSTGRES_DB=lexy
       - POSTGRES_HOST=db_postgres
+      - POSTGRES_TEST_DB=lexy_tests
       - CELERY_BROKER_URL=amqp://guest:guest@queue:5672//
       - CELERY_RESULT_BACKEND=db+postgresql://postgres:postgres@db_postgres/lexy
       - OPENAI_API_KEY=${OPENAI_API_KEY}

--- a/lexy/core/config.py
+++ b/lexy/core/config.py
@@ -57,17 +57,17 @@ class AppSettings(BaseSettings):
     FIRST_SUPERUSER_EMAIL: EmailStr = Field("lexy@lexy.ai", env="FIRST_SUPERUSER_EMAIL")
     FIRST_SUPERUSER_PASSWORD: SecretStr = Field("lexy", env="FIRST_SUPERUSER_PASSWORD")
 
-    # Default config for Collection objects
-    COLLECTION_DEFAULT_CONFIG: dict = {
-        'store_files': True,
-        'generate_thumbnails': True,
-    }
-
     # AWS settings & S3 storage settings
     AWS_ACCESS_KEY_ID: str = Field(default=None, env="AWS_ACCESS_KEY_ID")
     AWS_SECRET_ACCESS_KEY: SecretStr = Field(default=None, env="AWS_SECRET_ACCESS_KEY")
     AWS_REGION: str = Field(default=None, env="AWS_REGION")
     S3_BUCKET: str = Field(default=None, env="S3_BUCKET")
+
+    # Default config for Collection objects and images
+    COLLECTION_DEFAULT_CONFIG: dict = {
+        'store_files': True,
+        'generate_thumbnails': True,
+    }
     IMAGE_THUMBNAIL_SIZES: set[tuple] = {
         # (100, 100),
         (200, 200),
@@ -122,6 +122,18 @@ class AppSettings(BaseSettings):
         case_sensitive = True
         env_file = '.env'
         env_file_encoding = 'utf-8'
+
+
+class TestAppSettings(AppSettings):
+
+    # Database settings
+    POSTGRES_DB: str = Field(default="lexy_tests", env="POSTGRES_TEST_DB")
+    DB_ECHO_LOG: bool = True
+
+    # User settings
+    # without `env=` argument, this will revert to the environment value of FIRST_SUPERUSER_EMAIL
+    FIRST_SUPERUSER_EMAIL: EmailStr = Field("test@lexy.ai", env="TEST_SUPERUSER_EMAIL")
+    FIRST_SUPERUSER_PASSWORD: SecretStr = Field("test", env="TEST_SUPERUSER_PASSWORD")
 
 
 settings = AppSettings()

--- a/lexy/db/init_db.py
+++ b/lexy/db/init_db.py
@@ -4,7 +4,7 @@ from sqlalchemy.orm import sessionmaker
 from sqlalchemy.orm.session import close_all_sessions
 from sqlmodel import SQLModel
 
-from lexy.core.config import settings
+from lexy.core.config import settings as app_settings
 from lexy.db.sample_data import default_data, sample_docs
 from lexy.db.session import sync_engine
 from lexy import models  # noqa: make sure all models are imported before initializing DB
@@ -66,7 +66,7 @@ def add_sample_docs_to_db(session=db):
         session.commit()
 
 
-def add_first_superuser_to_db(session=db):
+def add_first_superuser_to_db(session=db, settings=app_settings):
     superuser = session.query(models.User).filter(models.User.email == settings.FIRST_SUPERUSER_EMAIL).first()
     if superuser:
         # issue a warning if superuser already exists in the database

--- a/lexy/db/session.py
+++ b/lexy/db/session.py
@@ -1,6 +1,6 @@
 from sqlalchemy.orm import sessionmaker
 from sqlmodel.ext.asyncio.session import AsyncSession, AsyncEngine
-from sqlmodel import create_engine, SQLModel
+from sqlmodel import create_engine
 
 from lexy.core.config import settings
 
@@ -24,14 +24,3 @@ async_session = sessionmaker(
 async def get_session() -> AsyncSession:
     async with async_session() as session:
         yield session
-
-
-async def create_db_and_tables():
-    async with async_engine.begin() as conn:
-        await conn.run_sync(SQLModel.metadata.create_all)
-
-
-async def recreate_db_and_tables():
-    async with async_engine.begin() as conn:
-        await conn.run_sync(SQLModel.metadata.drop_all)
-        await conn.run_sync(SQLModel.metadata.create_all)

--- a/lexy_tests/conftest.py
+++ b/lexy_tests/conftest.py
@@ -1,36 +1,145 @@
-import pytest
 import asyncio
 import httpx
+import pytest
 
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import sessionmaker
-from sqlmodel import create_engine, SQLModel
+from sqlmodel import Session, SQLModel, create_engine, delete
 from sqlmodel.ext.asyncio.session import AsyncSession, AsyncEngine
 
-from lexy.main import app
-from lexy.models.collection import Collection
+from lexy.core.config import TestAppSettings
+from lexy.db.init_db import add_default_data_to_db, add_first_superuser_to_db
+from lexy.db.session import get_session
+from lexy.api.deps import get_db
+from lexy.main import app as lexy_test_app
+from lexy import models
 
-# base_url = "http://127.0.0.1:9900/"
-base_url = "http://localhost:9900"
 
-# engine = create_engine(
-#     url="postgresql+asyncpg://postgres:postgres@localhost/lexy_tests",
-#     echo=False,
-#     future=True
-# )
-# TestSession = sessionmaker(autocommit=False, autoflush=False, bind=engine)
-#
-# @pytest.fixture(scope="session")
-# def db():
-#     yield TestSession()
+test_settings = TestAppSettings()
+DB_WARNING_MSG = "There's a good chance you're about to drop the wrong database! Double check your test settings."
+assert test_settings.POSTGRES_DB != "lexy", DB_WARNING_MSG
+test_settings.DB_ECHO_LOG = False
 
-# async_engine = AsyncEngine(create_engine(
-#     url="postgresql+asyncpg://postgres:postgres@localhost:5432/lexy_tests",
-#     echo=False,
-#     future=True
-# ))
+# TODO: need to update IndexManager and Celery to use the test database
 
-# FIXME: rewrite this using guide here: https://sqlmodel.tiangolo.com/tutorial/fastapi/tests/
+
+@pytest.fixture(scope="session")
+def settings() -> TestAppSettings:
+    """Fixture for test settings."""
+    print("settings: ", test_settings)
+    return test_settings
+
+
+@pytest.fixture(scope="session")
+def sync_engine(settings: TestAppSettings):
+    """Create a SQLAlchemy sync engine for the test database."""
+    engine = create_engine(
+        url=settings.sync_database_url,
+        echo=settings.DB_ECHO_LOG
+    )
+    print(f"sync_engine.url: {engine.url}")
+    return engine
+
+
+@pytest.fixture(scope="session")
+def async_engine(settings: TestAppSettings):
+    """Create a SQLAlchemy async engine for the test database."""
+    engine = AsyncEngine(
+        create_engine(
+            url=settings.async_database_url,
+            echo=settings.DB_ECHO_LOG
+        )
+    )
+    print(f"async_engine.url: {engine.url}")
+    return engine
+
+
+@pytest.fixture(scope="session")
+def create_test_database(sync_engine):
+    """Create test database and tables."""
+    with sync_engine.begin() as conn:
+        # If using SQLModel, replace YourBaseModel with SQLModel.metadata
+        print(f"Creating test DB tables with engine.url: {sync_engine.url}")
+        SQLModel.metadata.create_all(conn)
+        print("-- Kk, I created the tables --\n" * 3)
+    yield
+    with sync_engine.begin() as conn:
+        print(f"Dropping test DB tables with engine.url: {sync_engine.url}")
+        # TODO: need to make sure this isn't using the wrong instance of SQLModel.metadata
+        # SQLModel.metadata.drop_all(conn)
+
+
+# TODO: need to figure out how to make this function scoped
+@pytest.fixture(scope="session")
+def sync_session(sync_engine, create_test_database):
+    # """Create a new sync session for each test case."""
+    session = sessionmaker(autocommit=False, autoflush=False, bind=sync_engine)
+    with session() as s:
+        yield s
+
+
+@pytest.fixture(scope="session")
+def seed_data(sync_session: Session, settings: TestAppSettings):
+    """Seed the test database with data."""
+    # Add seed data to the test database
+    print("Seeding the test database with data")
+    # Add first superuser
+    add_first_superuser_to_db(session=sync_session, settings=settings)
+    # Add default data
+    add_default_data_to_db(session=sync_session)
+    # Uncomment the next line if you want to add sample documents
+    # add_sample_docs_to_db(session=sync_session)
+    yield
+    # Clean up the seed data after the tests
+    print("deleting seed data")
+    models_to_delete = [
+        models.User,
+        models.Binding,
+        models.Index,
+        models.Document,
+        models.Collection,
+        models.Transformer
+    ]
+    for model in models_to_delete:
+        # another way to do it
+        # sync_session.query(model).delete()
+        result = sync_session.execute(delete(model))
+        deleted_count = result.rowcount
+        print(f"deleting {deleted_count} {model.__name__} objects")
+    sync_session.commit()
+
+
+# TODO: need to figure out how to make this function scoped
+@pytest.fixture(scope="session")
+async def async_session(async_engine, create_test_database, seed_data):
+    # """Create a new async session for each test case."""
+    async_session = sessionmaker(
+        bind=async_engine, class_=AsyncSession, expire_on_commit=False
+    )
+    async with async_session() as session:
+        yield session
+
+
+@pytest.fixture(scope="session")
+def client(sync_session: Session, seed_data) -> TestClient:
+    """Fixture for providing a synchronous TestClient configured for testing."""
+    # Override get_session and get_db dependencies to use the test database session
+    lexy_test_app.dependency_overrides[get_session] = lambda: async_session
+    lexy_test_app.dependency_overrides[get_db] = lambda: async_session
+    with TestClient(app=lexy_test_app) as c:
+        yield c
+    lexy_test_app.dependency_overrides.clear()  # Reset overrides after tests
+
+
+@pytest.fixture(scope="session")
+async def async_client(async_session: AsyncSession) -> httpx.AsyncClient:
+    """Fixture for providing an asynchronous TestClient configured for testing."""
+    # Override get_session and get_db dependencies to use the test database session
+    lexy_test_app.dependency_overrides[get_session] = lambda: async_session
+    lexy_test_app.dependency_overrides[get_db] = lambda: async_session
+    async with httpx.AsyncClient(app=lexy_test_app, base_url="http://test") as ac:
+        yield ac
+    lexy_test_app.dependency_overrides.clear()  # Reset overrides after tests
 
 
 @pytest.fixture(scope="session")
@@ -38,51 +147,3 @@ def event_loop():
     loop = asyncio.get_event_loop()
     yield loop
     loop.close()
-
-
-@pytest.fixture(scope="session")
-def client():
-    with TestClient(app=app, base_url=base_url) as c:
-    # with httpx.Client(app=app, base_url=base_url, follow_redirects=True) as c:
-        yield c
-
-
-@pytest.fixture(scope="session")
-async def async_client():
-    async with httpx.AsyncClient(app=app, base_url=base_url, follow_redirects=True) as c:
-        yield c
-
-
-@pytest.fixture(scope="session")
-def async_engine():
-    return AsyncEngine(create_engine(
-        url="postgresql+asyncpg://postgres:postgres@localhost:5432/lexy_tests",
-        echo=True,
-        future=True
-    ))
-
-
-# @pytest.fixture()
-# def test_db():
-#     SQLModel.metadata.create_all(bind=engine)
-#     yield
-#     SQLModel.metadata.drop_all(bind=engine)
-
-
-@pytest.fixture(scope="session")
-async def async_session(async_engine):
-    async_session = sessionmaker(bind=async_engine, class_=AsyncSession, expire_on_commit=False)
-    async with async_session() as session:
-        yield session
-
-
-# @pytest.fixture(scope='session', autouse=True)
-# async def reset_db(async_engine, async_session):
-#     async with async_engine.begin() as conn:
-#         await conn.run_sync(SQLModel.metadata.drop_all)
-#         await conn.run_sync(SQLModel.metadata.create_all)
-#
-#     collection = Collection(collection_id="default", description="Default collection")
-#     async_session.add(collection)
-#     await async_session.commit()
-#     await async_session.refresh(collection)


### PR DESCRIPTION
# What

Running `pytest lexy_tests` now uses the test DB via dependency overrides. 

Still have a long ways to go for full test suite.
- Client tests still use the normal DB, need to switch them over
- Need to refactor IndexManager and Celery to use session dependencies

# Why

Without using the test DB, it's difficult to test things like creating new indexes and bindings.

# Test plan

- [x] Run ~~`pytest sdk-python`~~ `make run-tests` 
- [x] Run `examples/tests.ipynb` and verify that there are no errors
- [ ] Run `examples/tutorial.ipynb` and verify that the tutorial works as expected
- [ ] Run `examples/images.ipynb` and verify that the tutorial works as expected
