### PR TITLE
Integration testing

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -9,7 +9,7 @@ from sqlmodel import SQLModel  # ADDED
 from alembic import context
 
 from lexy.db import base  # noqa -- ADDED
-from lexy.indexes import index_manager  # noqa -- ADDED
+from lexy.api.deps import index_manager  # noqa -- ADDED
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
@@ -24,6 +24,7 @@ if config.config_file_name is not None:
 # for 'autogenerate' support
 # from myapp import mymodel
 # target_metadata = mymodel.Base.metadata
+index_manager.create_index_models()  # ADDED
 target_metadata = SQLModel.metadata  # UPDATED
 
 # other values from the config, defined by the needs of env.py,

--- a/docs/docs/contributing.md
+++ b/docs/docs/contributing.md
@@ -10,6 +10,24 @@ Coming soon.
 
 This section contains some common development tasks and how to perform them.
 
+### Running tests
+
+To run the tests, you can use the following make command.
+
+```bash
+make run-tests
+```
+
+This will run tests for the Lexy server and Lexy Python SDK. If you want to run the tests separately, you can use the following commands.
+
+```bash
+# Run tests for Lexy server
+pytest lexy_tests
+
+# Run tests for Python SDK
+pytest sdk-python
+```
+
 ### Adding a new migration
 
 To add a new `alembic` migration, first create the migration file.

--- a/lexy/api/deps.py
+++ b/lexy/api/deps.py
@@ -5,9 +5,10 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 from lexy.core.config import settings
 from lexy.core.security import ALGORITHM, oauth2_scheme, verify_password
-from lexy.db.session import get_session as get_db
+from lexy.db.session import get_session as get_db, get_sync_engine
 from lexy.models.user import User
 from lexy.schemas.token import TokenData
+from lexy.indexes import IndexManager
 
 
 async def get_user_by_email(db: AsyncSession, email: str) -> User:
@@ -55,3 +56,17 @@ async def authenticate_user(db: AsyncSession, *, email: str, password: str):
     if not verify_password(password, user.hashed_password):
         return False
     return user
+
+
+_index_manager: IndexManager | None = None
+
+
+def get_index_manager() -> IndexManager:
+    global _index_manager
+    if _index_manager is None:
+        engine = get_sync_engine()
+        _index_manager = IndexManager(engine=engine)
+    return _index_manager
+
+
+index_manager = get_index_manager()

--- a/lexy/api/endpoints/bindings.py
+++ b/lexy/api/endpoints/bindings.py
@@ -61,6 +61,7 @@ async def get_binding(binding_id: int,
     return binding
 
 
+# TODO: change to the following after SQLAlchemy 2.0: https://stackoverflow.com/a/75947988
 @router.patch("/bindings/{binding_id}",
               status_code=status.HTTP_200_OK,
               name="update_binding",
@@ -90,7 +91,7 @@ async def update_binding(binding_id: int,
         # TODO: this portion needs to be updated to reflect time stamps of tasks
         #  or to simply become part of an init script
         print(f"Binding status changed from '{old_status}' to 'on' - processing binding")
-        processed_binding, tasks = process_new_binding(db_binding)
+        processed_binding, tasks = await session.run_sync(process_new_binding, binding)
         # now commit the binding again and refresh it - status should be updated
         session.add(processed_binding)
         await session.commit()

--- a/lexy/api/endpoints/collections.py
+++ b/lexy/api/endpoints/collections.py
@@ -27,6 +27,12 @@ async def get_collections(session: AsyncSession = Depends(get_session)) -> list[
              name="add_collection",
              description="Create a new collection")
 async def add_collection(collection: CollectionCreate, session: AsyncSession = Depends(get_session)) -> Collection:
+    # check if collection already exists
+    result = await session.execute(select(exists().where(Collection.collection_id == collection.collection_id)))
+    existing_result = result.scalar()
+    if existing_result:
+        raise HTTPException(status_code=400, detail="Collection already exists")
+
     collection = Collection(**collection.dict())
     session.add(collection)
     await session.commit()
@@ -98,4 +104,4 @@ async def delete_collection(collection_id: str,
 
     await session.delete(collection)
     await session.commit()
-    return {"Say": "Collection deleted!", "collection_id": collection_id, "documents_deleted": deleted_count}
+    return {"msg": "Collection deleted", "collection_id": collection_id, "documents_deleted": deleted_count}

--- a/lexy/api/endpoints/utils.py
+++ b/lexy/api/endpoints/utils.py
@@ -72,3 +72,40 @@ async def celery_restart_worker(worker_name: str = 'celery@celeryworker'):
             description="Get task status")
 async def get_task_status(task_id: str, verbose: bool = False) -> dict:
     return get_task_info(task_id, verbose=verbose)
+
+
+@router.get("/tasks",
+            response_model=dict,
+            status_code=status.HTTP_200_OK,
+            name="get_all_tasks",
+            description="Get all tasks")
+async def get_all_tasks() -> dict:
+    return {"active": celery.control.inspect().active(),
+            "scheduled": celery.control.inspect().scheduled(),
+            "reserved": celery.control.inspect().reserved(),
+            "revoked": celery.control.inspect().revoked(),
+            "stats": celery.control.inspect().stats(),
+            "registered_tasks": celery.control.inspect().registered_tasks(),
+            "conf": celery.control.inspect().conf(with_defaults=False)}
+
+
+@router.get("/index-manager",
+            status_code=status.HTTP_200_OK,
+            name="get_index_manager")
+async def get_index_manager() -> dict:
+    from lexy.api.deps import index_manager
+    index_models_and_tables = dict(
+        (model, index_manager.index_models[model].__table__.name) for model in index_manager.index_models
+    )
+    return {"index_models_and_tables": index_models_and_tables}
+
+
+@router.get("/index-manager-celery",
+            status_code=status.HTTP_200_OK,
+            name="get_index_manager_from_celery")
+async def get_index_manager_from_celery() -> dict:
+    from lexy.core.celery_tasks import index_manager
+    index_models_and_tables = dict(
+        (model, index_manager.index_models[model].__table__.name) for model in index_manager.index_models
+    )
+    return {"index_models_and_tables": index_models_and_tables}

--- a/lexy/core/celery_app.py
+++ b/lexy/core/celery_app.py
@@ -2,11 +2,11 @@
 from celery import Celery
 from celery.result import AsyncResult
 
-from .config import settings as lexy_settings
-from .celery_config import settings
+from lexy.core.config import settings as lexy_settings
+from lexy.core.celery_config import settings as celery_settings
 
 
-def create_celery():
+def create_celery(settings=celery_settings):
     celery_app = Celery()
     celery_app.config_from_object(settings, namespace='CELERY')
     celery_app.conf.update(task_track_started=True)

--- a/lexy/core/celery_config.py
+++ b/lexy/core/celery_config.py
@@ -32,10 +32,20 @@ class DevelopmentConfig(BaseConfig):
     pass
 
 
+class TestingConfig(BaseConfig):
+    CELERY_BROKER_URL = "memory://"
+    CELERY_RESULT_BACKEND: str = "db+postgresql://postgres:postgres@localhost:5432/lexy_tests"
+    # task_always_eager: bool = True
+    # task_eager_propagates: bool = True
+    # task_store_eager_result: bool = True
+    # task_ignore_result: bool = False
+
+
 @lru_cache()
 def get_settings():
     config_cls_dict = {
         "development": DevelopmentConfig,
+        "testing": TestingConfig,
     }
     config_name = os.environ.get("CELERY_CONFIG", "development")
     config_cls = config_cls_dict[config_name]

--- a/lexy/db/session.py
+++ b/lexy/db/session.py
@@ -1,3 +1,4 @@
+from sqlalchemy.engine import Engine
 from sqlalchemy.orm import sessionmaker
 from sqlmodel.ext.asyncio.session import AsyncSession, AsyncEngine
 from sqlmodel import create_engine
@@ -19,6 +20,10 @@ async_engine = AsyncEngine(create_engine(
 async_session = sessionmaker(
     bind=async_engine, class_=AsyncSession, expire_on_commit=False
 )
+
+
+def get_sync_engine() -> Engine:
+    return sync_engine
 
 
 async def get_session() -> AsyncSession:

--- a/lexy/main.py
+++ b/lexy/main.py
@@ -1,33 +1,49 @@
+import contextlib
 import importlib
+import logging
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from lexy.core.celery_app import create_celery
 from lexy.core.config import settings
+from lexy.api.deps import index_manager
 from lexy.api.router import lexy_api
-from lexy.db.init_db import init_db
 
-# import transformer modules so that celery client can find them
+# Import transformer modules so that celery client can find them
 for module in settings.app_transformer_imports:
     importlib.import_module(module)
 
+# Create logger
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
 
-def create_app() -> FastAPI:
-    fastapi_app = FastAPI(
-        title=settings.TITLE,
-        version=settings.VERSION,
-        description=settings.DESCRIPTION,
-        openapi_prefix=settings.OPENAPI_PREFIX,
-        docs_url=settings.DOCS_URL,
-        openapi_url=settings.OPENAPI_URL
-    )
-    fastapi_app.include_router(lexy_api, prefix=settings.API_PREFIX)
-    return fastapi_app
+
+@contextlib.asynccontextmanager
+async def app_lifespan(app: FastAPI):
+    # NOTE: anything run here isn't run by celery workers
+    logger.info("Starting FastAPI app")
+    index_manager.create_index_models()
+    logger.debug("(main.app_lifespan) Created index models")
+    logger.debug(f"(main.app_lifespan) {index_manager = }")
+    logger.debug(f"(main.app_lifespan) {index_manager.index_models = }")
+    # Uncomment the next line to access the index_manager from the app state
+    # app.state.index_manager = index_manager
+    yield
+    logger.info("Stopping FastAPI app")
 
 
 # Create FastAPI app
-app = create_app()
+app = FastAPI(
+    title=settings.TITLE,
+    version=settings.VERSION,
+    description=settings.DESCRIPTION,
+    openapi_prefix=settings.OPENAPI_PREFIX,
+    docs_url=settings.DOCS_URL,
+    openapi_url=settings.OPENAPI_URL,
+    lifespan=app_lifespan
+)
+app.include_router(lexy_api, prefix=settings.API_PREFIX)
 
 # Create Celery app
 app.celery_app = create_celery()
@@ -45,12 +61,3 @@ app.add_middleware(
     allow_methods=["*"],  # allow all methods
     allow_headers=["*"],  # allow all headers
 )
-
-
-@app.on_event("startup")
-def on_startup():
-    print('starting app')
-    # this subsequent call to init_db() is only used by the index manager to create
-    # the default index table (default_text_embeddings) if it doesn't exist - we may
-    # be able to remove this call once seed data is added through proper crud endpoints
-    init_db()

--- a/lexy/models/index_record.py
+++ b/lexy/models/index_record.py
@@ -4,6 +4,7 @@ from uuid import uuid4, UUID
 
 from sqlalchemy import Column, DateTime, ForeignKey, func
 from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.sql.schema import Table
 from sqlmodel import SQLModel, Field, Relationship
 
 if TYPE_CHECKING:
@@ -30,6 +31,7 @@ class IndexRecordUpdate(IndexRecordBase):
 
 
 class IndexRecordBaseTable(IndexRecordBase):
+    __table__: Table | None = None
     index_record_id: UUID = Field(
         default_factory=uuid4,
         primary_key=True,

--- a/lexy_tests/conftest.py
+++ b/lexy_tests/conftest.py
@@ -1,17 +1,20 @@
+import os
+
 import asyncio
 import httpx
 import pytest
-
+from celery import current_app
 from fastapi.testclient import TestClient
+from sqlalchemy.engine import Engine
 from sqlalchemy.orm import sessionmaker
-from sqlmodel import Session, SQLModel, create_engine, delete
+from sqlalchemy.orm.session import close_all_sessions
+from sqlmodel import SQLModel, create_engine, delete
 from sqlmodel.ext.asyncio.session import AsyncSession, AsyncEngine
 
 from lexy.core.config import TestAppSettings
 from lexy.db.init_db import add_default_data_to_db, add_first_superuser_to_db
 from lexy.db.session import get_session
-from lexy.api.deps import get_db
-from lexy.main import app as lexy_test_app
+import lexy.db.session as db_session
 from lexy import models
 
 
@@ -20,13 +23,51 @@ DB_WARNING_MSG = "There's a good chance you're about to drop the wrong database!
 assert test_settings.POSTGRES_DB != "lexy", DB_WARNING_MSG
 test_settings.DB_ECHO_LOG = False
 
-# TODO: need to update IndexManager and Celery to use the test database
+
+# the value of CELERY_CONFIG is set using pytest-env plugin in pyproject.toml
+assert os.environ.get("CELERY_CONFIG") == "testing", "CELERY_CONFIG is not set to 'testing'"
+
+
+def create_test_engine(settings: TestAppSettings = test_settings) -> Engine:
+    """Create a SQLAlchemy sync engine for the test database."""
+    return create_engine(
+        url=settings.sync_database_url,
+        echo=settings.DB_ECHO_LOG
+    )
+
+
+test_engine = create_test_engine()
+assert test_engine.url.database != "lexy", DB_WARNING_MSG
+db_session.get_sync_engine = lambda: test_engine
+db_session.sync_engine = test_engine
+
+# in order to work, this has to come after `db_session.get_sync_engine` is overwritten
+from lexy.main import app as lexy_test_app  # noqa: E402
+
+
+# UPDATE: seems like this is no longer needed with the new celery_worker fixture?
+#    - https://docs.celeryq.dev/en/stable/userguide/testing.html#celery-worker-embed-live-worker
+# NOTE: task_always_eager is ignored when running celery.send_task, one option is to override the send_task method
+#  to return the result of the task synchronously. This approach is for integration testing, where we want to test
+#  the full flow of the application. It won't work for CI/CD, so we eventually need to move to mocking the celery
+#  tasks instead (using pytest-mock). Based on the following sources:
+#    - https://stackoverflow.com/a/35807024
+#    - https://stackoverflow.com/questions/35284043/mock-celery-task-method-apply-async
+#    - https://pytest-with-eric.com/pytest-advanced/mock-celery-task-pytest/
+#    - https://stackoverflow.com/questions/72129975/celery-integration-testing-with-pytest-and-monkeypatching
+# def send_task(name, args=(), kwargs={}, **opts):
+#     # https://github.com/celery/celery/issues/581
+#     task = current_app.tasks[name]
+#     return task.apply(args, kwargs, **opts)
+#
+#
+# current_app.send_task = send_task
 
 
 @pytest.fixture(scope="session")
 def settings() -> TestAppSettings:
     """Fixture for test settings."""
-    print("settings: ", test_settings)
+    print(f"{test_settings = }")
     return test_settings
 
 
@@ -55,43 +96,43 @@ def async_engine(settings: TestAppSettings):
 
 
 @pytest.fixture(scope="session")
-def create_test_database(sync_engine):
+def create_test_database(sync_engine, celery_session_app):
     """Create test database and tables."""
     with sync_engine.begin() as conn:
-        # If using SQLModel, replace YourBaseModel with SQLModel.metadata
         print(f"Creating test DB tables with engine.url: {sync_engine.url}")
         SQLModel.metadata.create_all(conn)
-        print("-- Kk, I created the tables --\n" * 3)
+        print("Created test DB tables")
     yield
     with sync_engine.begin() as conn:
-        print(f"Dropping test DB tables with engine.url: {sync_engine.url}")
-        # TODO: need to make sure this isn't using the wrong instance of SQLModel.metadata
-        # SQLModel.metadata.drop_all(conn)
-
-
-# TODO: need to figure out how to make this function scoped
-@pytest.fixture(scope="session")
-def sync_session(sync_engine, create_test_database):
-    # """Create a new sync session for each test case."""
-    session = sessionmaker(autocommit=False, autoflush=False, bind=sync_engine)
-    with session() as s:
-        yield s
+        lexy_table_names = ", ".join(SQLModel.metadata.tables.keys())
+        celery_table_names = ", ".join(celery_session_app.backend.task_cls.metadata.tables.keys())
+        celery_tables = celery_session_app.backend.task_cls.metadata.sorted_tables
+        print(f"Dropping test DB tables..."
+              f"\n\tengine.url: {sync_engine.url}"
+              f"\n\tlexy_table_names: {lexy_table_names}"
+              f"\n\tcelery_table_names: {celery_table_names}")
+        SQLModel.metadata.drop_all(conn)
+        celery_session_app.backend.task_cls.metadata.drop_all(conn, tables=celery_tables)
+        print("Dropped test DB tables")
 
 
 @pytest.fixture(scope="session")
-def seed_data(sync_session: Session, settings: TestAppSettings):
+def seed_data(settings: TestAppSettings, sync_engine: Engine, create_test_database):
     """Seed the test database with data."""
+    # Create a local sync session for seeding the test database
+    local_sessionmaker = sessionmaker(autocommit=False, autoflush=False, bind=sync_engine)
+    local_session = local_sessionmaker()
     # Add seed data to the test database
     print("Seeding the test database with data")
     # Add first superuser
-    add_first_superuser_to_db(session=sync_session, settings=settings)
+    add_first_superuser_to_db(session=local_session, settings=settings)
     # Add default data
-    add_default_data_to_db(session=sync_session)
+    add_default_data_to_db(session=local_session)
     # Uncomment the next line if you want to add sample documents
-    # add_sample_docs_to_db(session=sync_session)
+    # add_sample_docs_to_db(session=local_session)
     yield
     # Clean up the seed data after the tests
-    print("deleting seed data")
+    print("Deleting test DB data...")
     models_to_delete = [
         models.User,
         models.Binding,
@@ -103,16 +144,25 @@ def seed_data(sync_session: Session, settings: TestAppSettings):
     for model in models_to_delete:
         # another way to do it
         # sync_session.query(model).delete()
-        result = sync_session.execute(delete(model))
+        result = local_session.execute(delete(model))
         deleted_count = result.rowcount
-        print(f"deleting {deleted_count} {model.__name__} objects")
-    sync_session.commit()
+        print(f"\tdeleting {deleted_count} {model.__name__} objects")
+    local_session.commit()
+    close_all_sessions()
+    print("Deleted test DB data")
 
 
-# TODO: need to figure out how to make this function scoped
-@pytest.fixture(scope="session")
-async def async_session(async_engine, create_test_database, seed_data):
-    # """Create a new async session for each test case."""
+@pytest.fixture(scope="function")
+def sync_session(sync_engine, create_test_database):
+    """Create a new sync session for each test case."""
+    session = sessionmaker(autocommit=False, autoflush=False, bind=sync_engine)
+    with session() as s:
+        yield s
+
+
+@pytest.fixture(scope="function")
+async def async_session(async_engine, seed_data):
+    """Create a new async session for each test case."""
     async_session = sessionmaker(
         bind=async_engine, class_=AsyncSession, expire_on_commit=False
     )
@@ -121,25 +171,39 @@ async def async_session(async_engine, create_test_database, seed_data):
 
 
 @pytest.fixture(scope="session")
-def client(sync_session: Session, seed_data) -> TestClient:
+def client(seed_data) -> TestClient:
     """Fixture for providing a synchronous TestClient configured for testing."""
-    # Override get_session and get_db dependencies to use the test database session
+    # Override get_session dependency to use the test database session
     lexy_test_app.dependency_overrides[get_session] = lambda: async_session
-    lexy_test_app.dependency_overrides[get_db] = lambda: async_session
+    print('instantiating TestClient from within client fixture')
+    # this next line triggers the `@app.on_startup` event in lexy/main.py
     with TestClient(app=lexy_test_app) as c:
         yield c
     lexy_test_app.dependency_overrides.clear()  # Reset overrides after tests
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="function")
 async def async_client(async_session: AsyncSession) -> httpx.AsyncClient:
     """Fixture for providing an asynchronous TestClient configured for testing."""
-    # Override get_session and get_db dependencies to use the test database session
+    # Override get_session dependency to use the test database session
     lexy_test_app.dependency_overrides[get_session] = lambda: async_session
-    lexy_test_app.dependency_overrides[get_db] = lambda: async_session
+    print('instantiating Async TestClient from within async_client fixture')
+    # this next line does NOT trigger the `@app.on_startup` event in lexy/main.py
     async with httpx.AsyncClient(app=lexy_test_app, base_url="http://test") as ac:
         yield ac
     lexy_test_app.dependency_overrides.clear()  # Reset overrides after tests
+
+
+@pytest.fixture(scope="session")
+def celery_config():
+    return current_app.conf
+
+
+@pytest.fixture(scope="session")
+def use_celery_app_trap():
+    # throws an error if a test tries to access the default celery app - can override in tests that need it
+    #  using `@pytest.mark.usefixtures('depends_on_current_app')`
+    return True
 
 
 @pytest.fixture(scope="session")

--- a/lexy_tests/test_celery.py
+++ b/lexy_tests/test_celery.py
@@ -1,0 +1,60 @@
+# reference: https://docs.celeryq.dev/en/stable/userguide/testing.html
+
+
+class TestCelery:
+
+    def test_celery_app(self, celery_app, celery_worker, settings):
+        print(f"{celery_app = }")
+        print(f"{celery_app.conf.broker_url = }")
+        print(f"{celery_app.conf.result_backend = }")
+        assert celery_app
+
+        assert 'lexy.transformers.text.embeddings.minilm' in celery_app.tasks
+        assert 'lexy.db.save_records_to_index' in celery_app.tasks
+
+        save_records_task = celery_app.tasks.get('lexy.db.save_records_to_index')
+        assert save_records_task is not None
+        assert save_records_task.db.bind.engine.url.database == 'lexy_tests'
+        assert str(save_records_task.db.bind.engine.url) == settings.sync_database_url
+
+        text_embeddings_task = celery_app.tasks.get('lexy.transformers.text.embeddings.minilm')
+        assert text_embeddings_task is not None
+
+        eager_task = text_embeddings_task.apply(args=['hello world'])
+        eager_result = eager_task.get().tolist()
+        assert isinstance(eager_result, list)
+        assert all(isinstance(elem, float) for elem in eager_result)
+
+        eager_task = text_embeddings_task.apply(args=[['hello', 'world']])
+        eager_result = eager_task.get().tolist()
+        assert isinstance(eager_result, list)
+        assert all(isinstance(elem, list) for elem in eager_result)
+        assert all(isinstance(elem, float) for elem in eager_result[0])
+        assert all(isinstance(elem, float) for elem in eager_result[1])
+
+        # this hangs unless we include the celery_worker fixture
+        task = text_embeddings_task.apply_async(args=[['hello', 'world']])
+        assert isinstance(task.id, str)
+        result = task.get().tolist()
+        assert isinstance(result, list)
+        assert all(isinstance(elem, list) for elem in result)
+        assert all(isinstance(elem, float) for elem in result[0])
+        assert all(isinstance(elem, float) for elem in result[1])
+
+        # this times out unless we include the celery_worker fixture
+        task2 = text_embeddings_task.delay('hello world')
+        assert isinstance(task2.id, str)
+        result2 = task2.get(timeout=10).tolist()
+        assert isinstance(result2, list)
+        assert all(isinstance(elem, float) for elem in result2)
+
+    def test_celery_config(self, celery_config):
+        assert celery_config
+
+    def test_celery_worker(self, celery_worker):
+        print(f"{celery_worker = }")
+        assert celery_worker
+
+    def test_celery_session_worker(self, celery_session_worker):
+        print(f"{celery_session_worker = }")
+        assert celery_session_worker

--- a/poetry.lock
+++ b/poetry.lock
@@ -2178,6 +2178,38 @@ docs = ["sphinx (>=5.3)", "sphinx-rtd-theme (>=1.0)"]
 testing = ["coverage (>=6.2)", "flaky (>=3.5.0)", "hypothesis (>=5.7.1)", "mypy (>=0.931)", "pytest-trio (>=0.7.0)"]
 
 [[package]]
+name = "pytest-celery"
+version = "0.0.0"
+description = "pytest-celery a shim pytest plugin to enable celery.contrib.pytest"
+optional = false
+python-versions = "*"
+files = [
+    {file = "pytest-celery-0.0.0.tar.gz", hash = "sha256:cfd060fc32676afa1e4f51b2938f903f7f75d952186b8c6cf631628c4088f406"},
+    {file = "pytest_celery-0.0.0-py2.py3-none-any.whl", hash = "sha256:63dec132df3a839226ecb003ffdbb0c2cb88dd328550957e979c942766578060"},
+]
+
+[package.dependencies]
+celery = ">=4.4.0"
+
+[[package]]
+name = "pytest-env"
+version = "1.1.3"
+description = "pytest plugin that allows you to add environment variables."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pytest_env-1.1.3-py3-none-any.whl", hash = "sha256:aada77e6d09fcfb04540a6e462c58533c37df35fa853da78707b17ec04d17dfc"},
+    {file = "pytest_env-1.1.3.tar.gz", hash = "sha256:fcd7dc23bb71efd3d35632bde1bbe5ee8c8dc4489d6617fb010674880d96216b"},
+]
+
+[package.dependencies]
+pytest = ">=7.4.3"
+tomli = {version = ">=2.0.1", markers = "python_version < \"3.11\""}
+
+[package.extras]
+test = ["covdefaults (>=2.3)", "coverage (>=7.3.2)", "pytest-mock (>=3.12)"]
+
+[[package]]
 name = "pytest-httpx"
 version = "0.24.0"
 description = "Send responses to httpx."
@@ -3510,4 +3542,4 @@ lexy-transformers = ["openai", "sentence-transformers", "transformers"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "cefff0d51bfcee4470ef38dc68728e2c38e39a709c2de617f5d268bb7b3125bc"
+content-hash = "c38dd18d39b3c5523972bfce1e1dde183d60e91bd4050a43b5e29e118426c429"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,8 @@ pytest-mock = "^3.11.1"
 pytest-httpx = "^0.24.0"
 httpx = "^0.24.1"
 greenlet = ">=2.0.2"
+pytest-env = "^1.1.3"
+pytest-celery = "^0.0.0"
 
 [tool.poetry.group.docs.dependencies]
 mkdocs-material = "^9.3.1"
@@ -53,6 +55,10 @@ pymdown-extensions = "^10.3"
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+env = [
+    "RUN_ENV=test",
+    "CELERY_CONFIG=testing",
+]
 
 [build-system]
 requires = ["poetry>=1.2"]

--- a/sdk-python/lexy_py_tests/test_collection.py
+++ b/sdk-python/lexy_py_tests/test_collection.py
@@ -38,7 +38,7 @@ class TestCollectionClient:
 
         # delete test collection
         response = lexy.collection.delete_collection("test_collection")
-        assert response.get("Say") == "Collection deleted!"
+        assert response.get("msg") == "Collection deleted"
 
     def test_list_collections(self):
         collections = lexy.collection.list_collections()

--- a/sdk-python/lexy_py_tests/test_document.py
+++ b/sdk-python/lexy_py_tests/test_document.py
@@ -67,7 +67,7 @@ class TestDocumentClient:
 
         # delete test collection
         response = lexy.collection.delete_collection("tmp_collection")
-        assert response.get("Say") == "Collection deleted!"
+        assert response.get("msg") == "Collection deleted"
 
     def test_list_documents(self):
         documents = lexy.document.list_documents(collection_id='code')
@@ -109,7 +109,7 @@ class TestDocumentClient:
 
         # delete test collection
         response = lexy.collection.delete_collection("tmp_collection")
-        assert response.get("Say") == "Collection deleted!"
+        assert response.get("msg") == "Collection deleted"
 
     def test_add_documents_in_batches(self):
         # create a test collection for testing adding documents in batches
@@ -136,4 +136,4 @@ class TestDocumentClient:
 
         # delete test collection
         response = lexy.collection.delete_collection("tmp_collection")
-        assert response.get("Say") == "Collection deleted!"
+        assert response.get("msg") == "Collection deleted"


### PR DESCRIPTION
# What

We can now run E2E integration tests using the test database.

- Updated testing configuration
  + IndexManager now uses test DB engine
  + Celery fixtures, including app and worker
  + Celery tests module
  + Create and drop DB for each pytest session
  + Function scope for `client` and `async_session`
- Refactored IndexManager
  + Initiated within `lexy.api.deps` with a db engine argument
  + Instantiated once for FastAPI, and again for Celery tasks
  + Moved index table creation from `lexy.core.events` (and from `init_db`)
  + Deleted unused methods
- Refactored Celery settings
  + Added TestConfig
- New packages to enable better testing
  + `pytest-env`, `pytest-celery`
- Added documentation

Remaining TODOs related to this PR:

- Update sdk-python tests to use the new test DB and Celery instance
- Add more tests for the server
  + Bindings, Collections, Indexes, Transformers
  
# Why

Prior to this PR, we couldn't run integration tests, because it was difficult to get FastAPI, IndexManager, and Celery DB writers to all use the test database.

# Test plan

- [x] Run `make run-tests` and verify that all tests pass
- [x] Run `examples/tests.ipynb` and verify that there are no errors
- [x] Run `examples/tutorial.ipynb` and verify that the tutorial works as expected
- [ ] Run `examples/images.ipynb` and verify that the tutorial works as expected