### PR TITLE
Streamline testing

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,5 +8,4 @@
 
 - [ ] Run `make run-tests` and verify that all tests pass
 - [ ] Run `examples/tests.ipynb` and verify that there are no errors
-- [ ] Run `examples/tutorial.ipynb` and verify that the tutorial works as expected
 - [ ] Run `examples/images.ipynb` and verify that the tutorial works as expected

--- a/lexy/core/events.py
+++ b/lexy/core/events.py
@@ -93,19 +93,19 @@ def process_new_binding(session,
                 `binding.index.index_fields` is not defined
 
     """
-    logger.info(f"Processing new binding {binding}")
+    logger.info(f"Processing new {binding = }")
 
     # check if binding has a valid transformer
     if binding.transformer is None:
-        raise ValueError(f"Binding {binding} does not have a transformer associated with it")
+        raise ValueError(f"{binding = } does not have a transformer associated with it")
 
     # check if binding has a valid index
     if binding.index is None:
-        raise ValueError(f"Binding {binding} does not have an index associated with it")
+        raise ValueError(f"{binding = } does not have an index associated with it")
 
     # check that the binding has lexy_index_fields defined
     if "lexy_index_fields" not in binding.transformer_params.keys():
-        logger.info(f"Binding {binding} does not have 'lexy_index_fields' defined in 'transformer_params'")
+        logger.info(f"{binding = } does not have 'lexy_index_fields' defined in 'transformer_params'")
         if len(binding.index.index_fields) > 0:
             logger.info(f"Will assign them using 'index_fields' from index '{binding.index.index_id}'.")
 
@@ -116,7 +116,7 @@ def process_new_binding(session,
             binding.transformer_params["lexy_index_fields"] = list(binding.index.index_fields.keys())
             logger.info(f"Updated binding.transformer_params: {binding.transformer_params}")
         else:
-            raise ValueError(f"Binding {binding} does not have 'lexy_index_fields' defined in 'transformer_params' "
+            raise ValueError(f"{binding = } does not have 'lexy_index_fields' defined in 'transformer_params' "
                              f"and index '{binding.index.index_id}' does not have 'index_fields' defined. Either "
                              f"define 'lexy_index_fields' in 'transformer_params' or define 'index_fields' for index "
                              f"'{binding.index.index_id}'.")
@@ -150,9 +150,9 @@ def process_new_binding(session,
     # switch binding status to 'on'
     prev_status = binding.status
     binding.status = 'on'
-    logger.info(f"Set status for binding {binding}: from '{prev_status}' to 'on'")
+    logger.info(f"Set status for {binding = } - from '{prev_status}' to 'on'")
 
-    logger.info(f"Created {len(tasks)} tasks for binding {binding}: "
+    logger.info(f"Created {len(tasks)} tasks for {binding = }: "
                 f"[{', '.join([t['task_id'] for t in tasks])}]")
 
     return binding, tasks

--- a/sdk-python/lexy_py_tests/test_binding.py
+++ b/sdk-python/lexy_py_tests/test_binding.py
@@ -60,3 +60,27 @@ class TestBindingClient:
         assert isinstance(binding.transformer, Transformer)
         assert binding.transformer.transformer_id == "text.embeddings.minilm"
         assert isinstance(binding.transformer.client, LexyClient)
+
+    def test_create_binding(self, lx_client, celery_app, celery_worker):
+        binding = lx_client.create_binding(
+            collection_id="default",
+            index_id="default_text_embeddings",
+            transformer_id="text.embeddings.minilm",
+            description="Test Binding"
+
+        )
+        assert binding.binding_id is not None
+        assert binding.collection.collection_id == "default"
+        assert binding.index.index_id == "default_text_embeddings"
+        assert binding.transformer.transformer_id == "text.embeddings.minilm"
+        assert binding.description == "Test Binding"
+        assert binding.status == "on"
+        assert "lexy_index_fields" in binding.transformer_params
+        assert set(binding.index.index_fields.keys()) == set(binding.transformer_params["lexy_index_fields"])
+
+        # delete test binding
+        response = lx_client.delete_binding(binding_id=binding.binding_id)
+        assert response == {
+            "msg": "Binding deleted",
+            "binding_id": binding.binding_id
+        }

--- a/sdk-python/lexy_py_tests/test_tutorial.py
+++ b/sdk-python/lexy_py_tests/test_tutorial.py
@@ -1,0 +1,145 @@
+import time
+
+from lexy_py.client import LexyClient
+from lexy_py.binding.models import Binding
+from lexy_py.collection.models import Collection
+from lexy_py.index.models import Index
+from lexy_py.transformer.models import Transformer
+
+
+class TestTutorial:
+
+    def test_root(self, lx_client):
+        response = lx_client.get("/")
+        assert response.status_code == 200
+        assert response.json() == {"Say": "Hello!"}
+
+    # make sure that default collection is empty
+    def test_bulk_delete_documents(self, lx_client):
+        response = lx_client.bulk_delete_documents(collection_id="default")
+        assert response.get("msg") == "Documents deleted"
+
+        default_collection = lx_client.get_collection("default")
+        docs = default_collection.list_documents()
+        assert len(docs) == 0
+
+    def test_tutorial(self, lx_client, celery_app, celery_worker):
+
+        # Introduction
+
+        # adding documents to the default collection
+        first_doc, starlink_doc, latent_space_doc = lx_client.add_documents([
+            {"content": "This is my first document! It's great!"},
+            {"content": "Starlink is a satellite internet constellation operated by American aerospace company SpaceX, providing coverage to over 60 countries."},
+            {"content": "A latent space is an embedding of a set of items within a manifold in which items resembling each other are positioned closer to one another."}
+        ])
+
+        # wait for the celery worker to finish the embedding tasks
+        time.sleep(2)
+
+        # query the default index
+        response = lx_client.query_index("what is deep learning?")
+        assert len(response) == 3
+
+        # check that all documents are in the response
+        document_ids = [doc["document_id"] for doc in response]
+        assert first_doc.document_id in document_ids
+        assert starlink_doc.document_id in document_ids
+        assert latent_space_doc.document_id in document_ids
+
+        # check that the latent space document is the top result
+        assert response[0]["document_id"] == latent_space_doc.document_id
+
+        # Example: Famous biographies
+
+        # create a new collection
+        bios = lx_client.create_collection("bios", description="Famous Biographies")
+        assert isinstance(bios, Collection)
+        assert isinstance(bios.client, LexyClient)
+        assert bios.collection_id == "bios"
+        assert bios.description == "Famous Biographies"
+
+        # show empty collection
+        docs = bios.list_documents()
+        assert len(docs) == 0
+
+        # add documents to the bios collection
+        docs_added = bios.add_documents([
+            {"content": "Stephen Curry is an American professional basketball player for the Golden State Warriors."},
+            {"content": "Dwayne 'The Rock' Johnson is a well-known actor, former professional wrestler, and businessman."},
+            {"content": "Taylor Swift is a singer known for her songwriting, musical versatility, and artistic reinventions."}
+        ])
+        assert len(docs_added) == 3
+        bio_steph_curry = docs_added[0]
+        bio_the_rock = docs_added[1]
+        bio_taylor_swift = docs_added[2]
+
+        # check available transformers
+        transformers = lx_client.transformers
+        assert len(transformers) > 0
+        assert isinstance(transformers[0], Transformer)
+        transformer_ids = [t.transformer_id for t in transformers]
+        assert "text.embeddings.minilm" in transformer_ids
+
+        # create a new index for the bios collection
+        index_fields = {
+            "bio_embedding": {
+                "type": "embedding", "extras": {"dims": 384, "model": "text.embeddings.minilm"}
+            }
+        }
+        index = lx_client.create_index(
+            index_id="bios_index",
+            description="Biography embeddings",
+            index_fields=index_fields
+        )
+        assert isinstance(index, Index)
+        assert isinstance(index.client, LexyClient)
+        assert index.index_id == "bios_index"
+        assert index.description == "Biography embeddings"
+
+        # create a binding
+        binding = lx_client.create_binding(
+            collection_id="bios",
+            transformer_id="text.embeddings.minilm",
+            index_id="bios_index",
+        )
+        assert isinstance(binding, Binding)
+        assert isinstance(binding.client, LexyClient)
+        assert binding.collection.collection_id == "bios"
+        assert binding.index.index_id == "bios_index"
+        assert binding.transformer.transformer_id == "text.embeddings.minilm"
+        assert binding.status == "on"
+        assert "lexy_index_fields" in binding.transformer_params
+        assert set(binding.index.index_fields.keys()) == set(binding.transformer_params["lexy_index_fields"])
+
+        # wait for the celery worker to finish the embedding tasks
+        time.sleep(2)
+
+        # query the bios index
+        response = index.query(query_text="famous artists", query_field="bio_embedding", k=3)
+        assert len(response) == 3
+
+        # check that all documents are in the response
+        document_ids = [doc["document_id"] for doc in response]
+        assert bio_steph_curry.document_id in document_ids
+        assert bio_the_rock.document_id in document_ids
+        assert bio_taylor_swift.document_id in document_ids
+
+        # check that the taylor swift document is the top result
+        assert response[0]["document_id"] == bio_taylor_swift.document_id
+
+        # add a new document
+        doc_added = bios.add_documents([
+            {"content": "Beyoncé is a singer and songwriter recognized for her boundary-pushing artistry, vocals, and performances."}
+        ])
+        assert len(doc_added) == 1
+        beyonce_doc = doc_added[0]
+
+        # wait for the celery worker to finish the embedding tasks
+        time.sleep(0.5)
+
+        # query the bios index again
+        response = index.query(query_text="famous artists", query_field="bio_embedding", k=3)
+        assert len(response) == 3
+        document_ids = [doc["document_id"] for doc in response]
+        assert beyonce_doc.document_id in document_ids


### PR DESCRIPTION
# What

- Moved (most) tests from `tests.ipynb` to the new test framework
  + still need to add the image upload tests
- Created a test module for testing that the tutorial behaves as expected
- Added tests for creating indexes and bindings

# Why

We should just have one single test command that tests everything. Almost there. 

# Test plan

- [x] Run `make run-tests` and verify that all tests pass
- [x] Run `examples/tests.ipynb` and verify that there are no errors  <- will get rid of this after adding image upload tests
- [ ] ~~Run `examples/tutorial.ipynb` and verify that the tutorial works as expected~~  <- no longer needed
- [ ] Run `examples/images.ipynb` and verify that the tutorial works as expected
