### PR TITLE
Upgrade to SQLAlchemy 2.0

### DIFF
--- a/lexy/api/endpoints/users.py
+++ b/lexy/api/endpoints/users.py
@@ -16,8 +16,8 @@ router = APIRouter()
             description="Get all users (superuser only)",
             dependencies=[Depends(get_current_active_superuser)])
 async def get_users(session: AsyncSession = Depends(get_db)) -> list[UserRead]:
-    result = await session.execute(select(User))
-    users = result.scalars().all()
+    result = await session.exec(select(User))
+    users = result.all()
     return users
 
 
@@ -28,7 +28,7 @@ async def get_users(session: AsyncSession = Depends(get_db)) -> list[UserRead]:
             description="Get current user")
 async def get_user_me(current_user: User = Depends(get_current_active_user)) -> UserRead:
     # TODO: change the next line to `return current_user` after updating SQLModel
-    return UserRead.from_orm(current_user)
+    return UserRead.model_validate(current_user)
 
 
 @router.post("/users",
@@ -39,12 +39,12 @@ async def get_user_me(current_user: User = Depends(get_current_active_user)) -> 
              dependencies=[Depends(get_current_active_superuser)])
 async def create_user(user: UserCreate, session: AsyncSession = Depends(get_db)) -> UserRead:
     # check if user already exists
-    result = await session.execute(select(User).where(User.email == user.email))
-    existing_user = result.scalars().first()
+    result = await session.exec(select(User).where(User.email == user.email))
+    existing_user = result.first()
     if existing_user:
         raise HTTPException(status_code=400, detail="User email is already registered")
     # create new user
-    new_user = User.create(**user.dict())
+    new_user = User.create(**user.model_dump())
     session.add(new_user)
     await session.commit()
     await session.refresh(new_user)
@@ -62,7 +62,7 @@ async def get_user(user_id: int, session: AsyncSession = Depends(get_db)) -> Use
     if user is None:
         raise HTTPException(status_code=404, detail="User not found")
     # TODO: change the next line to `return user` after updating SQLModel
-    return UserRead.from_orm(user)
+    return UserRead.model_validate(user)
 
 
 @router.delete("/users/{user_id}",
@@ -85,14 +85,16 @@ async def delete_user(user_id: int, session: AsyncSession = Depends(get_db)) -> 
               name="update_user",
               description="Update a specific user (superuser only)",
               dependencies=[Depends(get_current_active_superuser)])
-async def update_user(user_id: int, user: UserUpdate, session: AsyncSession = Depends(get_db)) -> UserRead:
+async def update_user(user_id: int,
+                      user: UserUpdate,
+                      session: AsyncSession = Depends(get_db)) -> UserRead:
     db_user = await session.get(User, user_id)
     if db_user is None:
         raise HTTPException(status_code=404, detail="User not found")
-    update_data = user.dict(exclude_unset=True)
+    update_data = user.model_dump(exclude_unset=True)
     for field in update_data:
         setattr(db_user, field, update_data[field])
     await session.commit()
     await session.refresh(db_user)
     # TODO: change the next line to `return db_user` after updating SQLModel
-    return UserRead.from_orm(db_user)
+    return UserRead.model_validate(db_user)

--- a/lexy/db/session.py
+++ b/lexy/db/session.py
@@ -1,23 +1,24 @@
 from sqlalchemy.engine import Engine
-from sqlalchemy.orm import sessionmaker
-from sqlmodel.ext.asyncio.session import AsyncSession, AsyncEngine
+from sqlalchemy.ext.asyncio import AsyncEngine, async_sessionmaker, create_async_engine
 from sqlmodel import create_engine
+from sqlmodel.ext.asyncio.session import AsyncSession
 
 from lexy.core.config import settings
 
 
-sync_engine = create_engine(
+sync_engine: Engine = create_engine(
     url=settings.sync_database_url,
-    echo=settings.DB_ECHO_LOG
+    echo=settings.DB_ECHO_LOG,
+    future=True
 )
 
-async_engine = AsyncEngine(create_engine(
+async_engine: AsyncEngine = create_async_engine(
     url=settings.async_database_url,
     echo=settings.DB_ECHO_LOG,
     future=True
-))
+)
 
-async_session = sessionmaker(
+async_session = async_sessionmaker(
     bind=async_engine, class_=AsyncSession, expire_on_commit=False
 )
 

--- a/lexy/models/binding.py
+++ b/lexy/models/binding.py
@@ -47,9 +47,11 @@ class Binding(BindingBase, table=True):
     __tablename__ = "bindings"
     binding_id: int = Field(default=None, primary_key=True)
     created_at: datetime = Field(
+        default=None,
         sa_column=Column(DateTime(timezone=True), nullable=False, server_default=func.now()),
     )
     updated_at: datetime = Field(
+        default=None,
         sa_column=Column(DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now()),
     )
     status: str = Field(default=BindingStatus.PENDING, nullable=False)

--- a/lexy/models/collection.py
+++ b/lexy/models/collection.py
@@ -27,9 +27,11 @@ class CollectionBase(SQLModel):
 class Collection(CollectionBase, table=True):
     __tablename__ = "collections"
     created_at: datetime = Field(
+        default=None,
         sa_column=Column(DateTime(timezone=True), nullable=False, server_default=func.now()),
     )
     updated_at: datetime = Field(
+        default=None,
         sa_column=Column(DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now()),
     )
     documents: list["Document"] = Relationship(

--- a/lexy/models/document.py
+++ b/lexy/models/document.py
@@ -84,9 +84,11 @@ class Document(DocumentBase, table=True):
         nullable=False,
     )
     created_at: datetime = Field(
+        default=None,
         sa_column=Column(DateTime(timezone=True), nullable=False, server_default=func.now()),
     )
     updated_at: datetime = Field(
+        default=None,
         sa_column=Column(DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now()),
     )
     collection_id: str = Field(default="default", foreign_key="collections.collection_id")

--- a/lexy/models/index.py
+++ b/lexy/models/index.py
@@ -29,9 +29,11 @@ class IndexBase(SQLModel):
 class Index(IndexBase, table=True):
     __tablename__ = "indexes"
     created_at: datetime = Field(
+        default=None,
         sa_column=Column(DateTime(timezone=True), nullable=False, server_default=func.now()),
     )
     updated_at: datetime = Field(
+        default=None,
         sa_column=Column(DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now()),
     )
     bindings: list["Binding"] = Relationship(

--- a/lexy/models/index_record.py
+++ b/lexy/models/index_record.py
@@ -39,9 +39,11 @@ class IndexRecordBaseTable(IndexRecordBase):
         nullable=False,
     )
     created_at: datetime = Field(
+        default=None,
         sa_column=Column(DateTime(timezone=True), nullable=False, server_default=func.now()),
     )
     updated_at: datetime = Field(
+        default=None,
         sa_column=Column(DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now()),
     )
     document: "Document" = Relationship(back_populates="index_records")

--- a/lexy/models/transformer.py
+++ b/lexy/models/transformer.py
@@ -33,9 +33,11 @@ class TransformerBase(SQLModel):
 class Transformer(TransformerBase, table=True):
     __tablename__ = "transformers"
     created_at: datetime = Field(
+        default=None,
         sa_column=Column(DateTime(timezone=True), nullable=False, server_default=func.now()),
     )
     updated_at: datetime = Field(
+        default=None,
         sa_column=Column(DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now()),
     )
     bindings: list["Binding"] = Relationship(back_populates="transformer")

--- a/lexy/server_prestart.py
+++ b/lexy/server_prestart.py
@@ -1,6 +1,7 @@
 import logging
 
 from sqlalchemy.orm import sessionmaker
+from sqlalchemy.sql import text
 
 from lexy.db.session import sync_engine
 
@@ -14,7 +15,7 @@ def init() -> None:
     try:
         db = SyncSessionLocal()
         # Try to create session to check if DB is awake
-        db.execute("SELECT 1")
+        db.execute(text("SELECT 1"))
     except Exception as e:
         logger.error(e)
         raise e

--- a/lexy_tests/test_celery.py
+++ b/lexy_tests/test_celery.py
@@ -15,7 +15,7 @@ class TestCelery:
         save_records_task = celery_app.tasks.get('lexy.db.save_records_to_index')
         assert save_records_task is not None
         assert save_records_task.db.bind.engine.url.database == 'lexy_tests'
-        assert str(save_records_task.db.bind.engine.url) == settings.sync_database_url
+        assert save_records_task.db.bind.engine.url.render_as_string(hide_password=False) == settings.sync_database_url
 
         text_embeddings_task = celery_app.tasks.get('lexy.transformers.text.embeddings.minilm')
         assert text_embeddings_task is not None

--- a/lexy_tests/test_collection.py
+++ b/lexy_tests/test_collection.py
@@ -11,8 +11,8 @@ class TestCollection:
 
     @pytest.mark.asyncio
     async def test_get_collections(self, async_session):
-        result = await async_session.execute(select(Collection))
-        collections = result.scalars().all()
+        result = await async_session.exec(select(Collection))
+        collections = result.all()
         assert len(collections) > 1
         collection_ids = [c.collection_id for c in collections]
         assert "default" in collection_ids
@@ -49,8 +49,8 @@ class TestCollection:
         assert collection.created_at is not None
         assert collection.updated_at is not None
 
-        result = await async_session.execute(select(Collection).where(Collection.collection_id == "test_collection"))
-        collections = result.scalars().all()
+        result = await async_session.exec(select(Collection).where(Collection.collection_id == "test_collection"))
+        collections = result.all()
         assert len(collections) == 1
         assert collections[0].collection_id == "test_collection"
         assert collections[0].description == "Test Collection"

--- a/lexy_tests/test_document.py
+++ b/lexy_tests/test_document.py
@@ -21,8 +21,8 @@ class TestDocument:
         assert document.created_at is not None
         assert document.updated_at is not None
 
-        result = await async_session.execute(select(Document))
-        documents = result.scalars().all()
+        result = await async_session.exec(select(Document))
+        documents = result.all()
         assert len(documents) == 1
         assert documents[0].content == "Test Content"
 
@@ -59,6 +59,11 @@ class TestDocument:
         doc1 = Document(content="import this", collection_id='code')
         doc2 = Document(content="export that", collection_id='code')
         async_session.add(doc1)
+        # TODO: remove the next line and use only a single commit
+        #  Requires SQLModel to update the GUID class, or SQLAlchemy update to 2.0.29. See the issues below.
+        #  - SQLAlchemy: https://github.com/sqlalchemy/sqlalchemy/issues/11160
+        #  - SQLModel: https://github.com/tiangolo/sqlmodel/discussions/843
+        await async_session.commit()
         async_session.add(doc2)
         await async_session.commit()
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -2931,112 +2931,105 @@ files = [
 
 [[package]]
 name = "sqlalchemy"
-version = "1.4.51"
+version = "2.0.28"
 description = "Database Abstraction Library"
 optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7"
+python-versions = ">=3.7"
 files = [
-    {file = "SQLAlchemy-1.4.51-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:1a09d5bd1a40d76ad90e5570530e082ddc000e1d92de495746f6257dc08f166b"},
-    {file = "SQLAlchemy-1.4.51-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2be4e6294c53f2ec8ea36486b56390e3bcaa052bf3a9a47005687ccf376745d1"},
-    {file = "SQLAlchemy-1.4.51-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8ca484ca11c65e05639ffe80f20d45e6be81fbec7683d6c9a15cd421e6e8b340"},
-    {file = "SQLAlchemy-1.4.51-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:0535d5b57d014d06ceeaeffd816bb3a6e2dddeb670222570b8c4953e2d2ea678"},
-    {file = "SQLAlchemy-1.4.51-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:af55cc207865d641a57f7044e98b08b09220da3d1b13a46f26487cc2f898a072"},
-    {file = "SQLAlchemy-1.4.51-cp310-cp310-win32.whl", hash = "sha256:7af40425ac535cbda129d9915edcaa002afe35d84609fd3b9d6a8c46732e02ee"},
-    {file = "SQLAlchemy-1.4.51-cp310-cp310-win_amd64.whl", hash = "sha256:8d1d7d63e5d2f4e92a39ae1e897a5d551720179bb8d1254883e7113d3826d43c"},
-    {file = "SQLAlchemy-1.4.51-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:eaeeb2464019765bc4340214fca1143081d49972864773f3f1e95dba5c7edc7d"},
-    {file = "SQLAlchemy-1.4.51-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7deeae5071930abb3669b5185abb6c33ddfd2398f87660fafdb9e6a5fb0f3f2f"},
-    {file = "SQLAlchemy-1.4.51-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0892e7ac8bc76da499ad3ee8de8da4d7905a3110b952e2a35a940dab1ffa550e"},
-    {file = "SQLAlchemy-1.4.51-cp311-cp311-win32.whl", hash = "sha256:50e074aea505f4427151c286955ea025f51752fa42f9939749336672e0674c81"},
-    {file = "SQLAlchemy-1.4.51-cp311-cp311-win_amd64.whl", hash = "sha256:3b0cd89a7bd03f57ae58263d0f828a072d1b440c8c2949f38f3b446148321171"},
-    {file = "SQLAlchemy-1.4.51-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:a33cb3f095e7d776ec76e79d92d83117438b6153510770fcd57b9c96f9ef623d"},
-    {file = "SQLAlchemy-1.4.51-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6cacc0b2dd7d22a918a9642fc89840a5d3cee18a0e1fe41080b1141b23b10916"},
-    {file = "SQLAlchemy-1.4.51-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:245c67c88e63f1523e9216cad6ba3107dea2d3ee19adc359597a628afcabfbcb"},
-    {file = "SQLAlchemy-1.4.51-cp312-cp312-win32.whl", hash = "sha256:8e702e7489f39375601c7ea5a0bef207256828a2bc5986c65cb15cd0cf097a87"},
-    {file = "SQLAlchemy-1.4.51-cp312-cp312-win_amd64.whl", hash = "sha256:0525c4905b4b52d8ccc3c203c9d7ab2a80329ffa077d4bacf31aefda7604dc65"},
-    {file = "SQLAlchemy-1.4.51-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:1980e6eb6c9be49ea8f89889989127daafc43f0b1b6843d71efab1514973cca0"},
-    {file = "SQLAlchemy-1.4.51-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3ec7a0ed9b32afdf337172678a4a0e6419775ba4e649b66f49415615fa47efbd"},
-    {file = "SQLAlchemy-1.4.51-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:352df882088a55293f621328ec33b6ffca936ad7f23013b22520542e1ab6ad1b"},
-    {file = "SQLAlchemy-1.4.51-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:86a22143a4001f53bf58027b044da1fb10d67b62a785fc1390b5c7f089d9838c"},
-    {file = "SQLAlchemy-1.4.51-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c37bc677690fd33932182b85d37433845de612962ed080c3e4d92f758d1bd894"},
-    {file = "SQLAlchemy-1.4.51-cp36-cp36m-win32.whl", hash = "sha256:d0a83afab5e062abffcdcbcc74f9d3ba37b2385294dd0927ad65fc6ebe04e054"},
-    {file = "SQLAlchemy-1.4.51-cp36-cp36m-win_amd64.whl", hash = "sha256:a61184c7289146c8cff06b6b41807c6994c6d437278e72cf00ff7fe1c7a263d1"},
-    {file = "SQLAlchemy-1.4.51-cp37-cp37m-macosx_11_0_x86_64.whl", hash = "sha256:3f0ef620ecbab46e81035cf3dedfb412a7da35340500ba470f9ce43a1e6c423b"},
-    {file = "SQLAlchemy-1.4.51-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2c55040d8ea65414de7c47f1a23823cd9f3fad0dc93e6b6b728fee81230f817b"},
-    {file = "SQLAlchemy-1.4.51-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:38ef80328e3fee2be0a1abe3fe9445d3a2e52a1282ba342d0dab6edf1fef4707"},
-    {file = "SQLAlchemy-1.4.51-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f8cafa6f885a0ff5e39efa9325195217bb47d5929ab0051636610d24aef45ade"},
-    {file = "SQLAlchemy-1.4.51-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e8f2df79a46e130235bc5e1bbef4de0583fb19d481eaa0bffa76e8347ea45ec6"},
-    {file = "SQLAlchemy-1.4.51-cp37-cp37m-win32.whl", hash = "sha256:f2e5b6f5cf7c18df66d082604a1d9c7a2d18f7d1dbe9514a2afaccbb51cc4fc3"},
-    {file = "SQLAlchemy-1.4.51-cp37-cp37m-win_amd64.whl", hash = "sha256:5e180fff133d21a800c4f050733d59340f40d42364fcb9d14f6a67764bdc48d2"},
-    {file = "SQLAlchemy-1.4.51-cp38-cp38-macosx_11_0_x86_64.whl", hash = "sha256:7d8139ca0b9f93890ab899da678816518af74312bb8cd71fb721436a93a93298"},
-    {file = "SQLAlchemy-1.4.51-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eb18549b770351b54e1ab5da37d22bc530b8bfe2ee31e22b9ebe650640d2ef12"},
-    {file = "SQLAlchemy-1.4.51-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:55e699466106d09f028ab78d3c2e1f621b5ef2c8694598242259e4515715da7c"},
-    {file = "SQLAlchemy-1.4.51-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:2ad16880ccd971ac8e570550fbdef1385e094b022d6fc85ef3ce7df400dddad3"},
-    {file = "SQLAlchemy-1.4.51-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b97fd5bb6b7c1a64b7ac0632f7ce389b8ab362e7bd5f60654c2a418496be5d7f"},
-    {file = "SQLAlchemy-1.4.51-cp38-cp38-win32.whl", hash = "sha256:cecb66492440ae8592797dd705a0cbaa6abe0555f4fa6c5f40b078bd2740fc6b"},
-    {file = "SQLAlchemy-1.4.51-cp38-cp38-win_amd64.whl", hash = "sha256:39b02b645632c5fe46b8dd30755682f629ffbb62ff317ecc14c998c21b2896ff"},
-    {file = "SQLAlchemy-1.4.51-cp39-cp39-macosx_11_0_x86_64.whl", hash = "sha256:b03850c290c765b87102959ea53299dc9addf76ca08a06ea98383348ae205c99"},
-    {file = "SQLAlchemy-1.4.51-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e646b19f47d655261b22df9976e572f588185279970efba3d45c377127d35349"},
-    {file = "SQLAlchemy-1.4.51-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d3cf56cc36d42908495760b223ca9c2c0f9f0002b4eddc994b24db5fcb86a9e4"},
-    {file = "SQLAlchemy-1.4.51-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:0d661cff58c91726c601cc0ee626bf167b20cc4d7941c93c5f3ac28dc34ddbea"},
-    {file = "SQLAlchemy-1.4.51-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3823dda635988e6744d4417e13f2e2b5fe76c4bf29dd67e95f98717e1b094cad"},
-    {file = "SQLAlchemy-1.4.51-cp39-cp39-win32.whl", hash = "sha256:b00cf0471888823b7a9f722c6c41eb6985cf34f077edcf62695ac4bed6ec01ee"},
-    {file = "SQLAlchemy-1.4.51-cp39-cp39-win_amd64.whl", hash = "sha256:a055ba17f4675aadcda3005df2e28a86feb731fdcc865e1f6b4f209ed1225cba"},
-    {file = "SQLAlchemy-1.4.51.tar.gz", hash = "sha256:e7908c2025eb18394e32d65dd02d2e37e17d733cdbe7d78231c2b6d7eb20cdb9"},
+    {file = "SQLAlchemy-2.0.28-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e0b148ab0438f72ad21cb004ce3bdaafd28465c4276af66df3b9ecd2037bf252"},
+    {file = "SQLAlchemy-2.0.28-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:bbda76961eb8f27e6ad3c84d1dc56d5bc61ba8f02bd20fcf3450bd421c2fcc9c"},
+    {file = "SQLAlchemy-2.0.28-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:feea693c452d85ea0015ebe3bb9cd15b6f49acc1a31c28b3c50f4db0f8fb1e71"},
+    {file = "SQLAlchemy-2.0.28-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5da98815f82dce0cb31fd1e873a0cb30934971d15b74e0d78cf21f9e1b05953f"},
+    {file = "SQLAlchemy-2.0.28-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:4a5adf383c73f2d49ad15ff363a8748319ff84c371eed59ffd0127355d6ea1da"},
+    {file = "SQLAlchemy-2.0.28-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:56856b871146bfead25fbcaed098269d90b744eea5cb32a952df00d542cdd368"},
+    {file = "SQLAlchemy-2.0.28-cp310-cp310-win32.whl", hash = "sha256:943aa74a11f5806ab68278284a4ddd282d3fb348a0e96db9b42cb81bf731acdc"},
+    {file = "SQLAlchemy-2.0.28-cp310-cp310-win_amd64.whl", hash = "sha256:c6c4da4843e0dabde41b8f2e8147438330924114f541949e6318358a56d1875a"},
+    {file = "SQLAlchemy-2.0.28-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:46a3d4e7a472bfff2d28db838669fc437964e8af8df8ee1e4548e92710929adc"},
+    {file = "SQLAlchemy-2.0.28-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0d3dd67b5d69794cfe82862c002512683b3db038b99002171f624712fa71aeaa"},
+    {file = "SQLAlchemy-2.0.28-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c61e2e41656a673b777e2f0cbbe545323dbe0d32312f590b1bc09da1de6c2a02"},
+    {file = "SQLAlchemy-2.0.28-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0315d9125a38026227f559488fe7f7cee1bd2fbc19f9fd637739dc50bb6380b2"},
+    {file = "SQLAlchemy-2.0.28-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:af8ce2d31679006e7b747d30a89cd3ac1ec304c3d4c20973f0f4ad58e2d1c4c9"},
+    {file = "SQLAlchemy-2.0.28-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:81ba314a08c7ab701e621b7ad079c0c933c58cdef88593c59b90b996e8b58fa5"},
+    {file = "SQLAlchemy-2.0.28-cp311-cp311-win32.whl", hash = "sha256:1ee8bd6d68578e517943f5ebff3afbd93fc65f7ef8f23becab9fa8fb315afb1d"},
+    {file = "SQLAlchemy-2.0.28-cp311-cp311-win_amd64.whl", hash = "sha256:ad7acbe95bac70e4e687a4dc9ae3f7a2f467aa6597049eeb6d4a662ecd990bb6"},
+    {file = "SQLAlchemy-2.0.28-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:d3499008ddec83127ab286c6f6ec82a34f39c9817f020f75eca96155f9765097"},
+    {file = "SQLAlchemy-2.0.28-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:9b66fcd38659cab5d29e8de5409cdf91e9986817703e1078b2fdaad731ea66f5"},
+    {file = "SQLAlchemy-2.0.28-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bea30da1e76cb1acc5b72e204a920a3a7678d9d52f688f087dc08e54e2754c67"},
+    {file = "SQLAlchemy-2.0.28-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:124202b4e0edea7f08a4db8c81cc7859012f90a0d14ba2bf07c099aff6e96462"},
+    {file = "SQLAlchemy-2.0.28-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:e23b88c69497a6322b5796c0781400692eca1ae5532821b39ce81a48c395aae9"},
+    {file = "SQLAlchemy-2.0.28-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:4b6303bfd78fb3221847723104d152e5972c22367ff66edf09120fcde5ddc2e2"},
+    {file = "SQLAlchemy-2.0.28-cp312-cp312-win32.whl", hash = "sha256:a921002be69ac3ab2cf0c3017c4e6a3377f800f1fca7f254c13b5f1a2f10022c"},
+    {file = "SQLAlchemy-2.0.28-cp312-cp312-win_amd64.whl", hash = "sha256:b4a2cf92995635b64876dc141af0ef089c6eea7e05898d8d8865e71a326c0385"},
+    {file = "SQLAlchemy-2.0.28-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:8e91b5e341f8c7f1e5020db8e5602f3ed045a29f8e27f7f565e0bdee3338f2c7"},
+    {file = "SQLAlchemy-2.0.28-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:45c7b78dfc7278329f27be02c44abc0d69fe235495bb8e16ec7ef1b1a17952db"},
+    {file = "SQLAlchemy-2.0.28-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3eba73ef2c30695cb7eabcdb33bb3d0b878595737479e152468f3ba97a9c22a4"},
+    {file = "SQLAlchemy-2.0.28-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:5df5d1dafb8eee89384fb7a1f79128118bc0ba50ce0db27a40750f6f91aa99d5"},
+    {file = "SQLAlchemy-2.0.28-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:2858bbab1681ee5406650202950dc8f00e83b06a198741b7c656e63818633526"},
+    {file = "SQLAlchemy-2.0.28-cp37-cp37m-win32.whl", hash = "sha256:9461802f2e965de5cff80c5a13bc945abea7edaa1d29360b485c3d2b56cdb075"},
+    {file = "SQLAlchemy-2.0.28-cp37-cp37m-win_amd64.whl", hash = "sha256:a6bec1c010a6d65b3ed88c863d56b9ea5eeefdf62b5e39cafd08c65f5ce5198b"},
+    {file = "SQLAlchemy-2.0.28-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:843a882cadebecc655a68bd9a5b8aa39b3c52f4a9a5572a3036fb1bb2ccdc197"},
+    {file = "SQLAlchemy-2.0.28-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:dbb990612c36163c6072723523d2be7c3eb1517bbdd63fe50449f56afafd1133"},
+    {file = "SQLAlchemy-2.0.28-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bd7e4baf9161d076b9a7e432fce06217b9bd90cfb8f1d543d6e8c4595627edb9"},
+    {file = "SQLAlchemy-2.0.28-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e0a5354cb4de9b64bccb6ea33162cb83e03dbefa0d892db88a672f5aad638a75"},
+    {file = "SQLAlchemy-2.0.28-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:fffcc8edc508801ed2e6a4e7b0d150a62196fd28b4e16ab9f65192e8186102b6"},
+    {file = "SQLAlchemy-2.0.28-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:aca7b6d99a4541b2ebab4494f6c8c2f947e0df4ac859ced575238e1d6ca5716b"},
+    {file = "SQLAlchemy-2.0.28-cp38-cp38-win32.whl", hash = "sha256:8c7f10720fc34d14abad5b647bc8202202f4948498927d9f1b4df0fb1cf391b7"},
+    {file = "SQLAlchemy-2.0.28-cp38-cp38-win_amd64.whl", hash = "sha256:243feb6882b06a2af68ecf4bec8813d99452a1b62ba2be917ce6283852cf701b"},
+    {file = "SQLAlchemy-2.0.28-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:fc4974d3684f28b61b9a90fcb4c41fb340fd4b6a50c04365704a4da5a9603b05"},
+    {file = "SQLAlchemy-2.0.28-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:87724e7ed2a936fdda2c05dbd99d395c91ea3c96f029a033a4a20e008dd876bf"},
+    {file = "SQLAlchemy-2.0.28-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:68722e6a550f5de2e3cfe9da6afb9a7dd15ef7032afa5651b0f0c6b3adb8815d"},
+    {file = "SQLAlchemy-2.0.28-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:328529f7c7f90adcd65aed06a161851f83f475c2f664a898af574893f55d9e53"},
+    {file = "SQLAlchemy-2.0.28-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:df40c16a7e8be7413b885c9bf900d402918cc848be08a59b022478804ea076b8"},
+    {file = "SQLAlchemy-2.0.28-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:426f2fa71331a64f5132369ede5171c52fd1df1bd9727ce621f38b5b24f48750"},
+    {file = "SQLAlchemy-2.0.28-cp39-cp39-win32.whl", hash = "sha256:33157920b233bc542ce497a81a2e1452e685a11834c5763933b440fedd1d8e2d"},
+    {file = "SQLAlchemy-2.0.28-cp39-cp39-win_amd64.whl", hash = "sha256:2f60843068e432311c886c5f03c4664acaef507cf716f6c60d5fde7265be9d7b"},
+    {file = "SQLAlchemy-2.0.28-py3-none-any.whl", hash = "sha256:78bb7e8da0183a8301352d569900d9d3594c48ac21dc1c2ec6b3121ed8b6c986"},
+    {file = "SQLAlchemy-2.0.28.tar.gz", hash = "sha256:dd53b6c4e6d960600fd6532b79ee28e2da489322fcf6648738134587faf767b6"},
 ]
 
 [package.dependencies]
-greenlet = {version = "!=0.4.17", markers = "python_version >= \"3\" and (platform_machine == \"aarch64\" or platform_machine == \"ppc64le\" or platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"win32\" or platform_machine == \"WIN32\")"}
+greenlet = {version = "!=0.4.17", markers = "platform_machine == \"aarch64\" or platform_machine == \"ppc64le\" or platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"win32\" or platform_machine == \"WIN32\""}
+typing-extensions = ">=4.6.0"
 
 [package.extras]
 aiomysql = ["aiomysql (>=0.2.0)", "greenlet (!=0.4.17)"]
+aioodbc = ["aioodbc", "greenlet (!=0.4.17)"]
 aiosqlite = ["aiosqlite", "greenlet (!=0.4.17)", "typing_extensions (!=3.10.0.1)"]
 asyncio = ["greenlet (!=0.4.17)"]
-asyncmy = ["asyncmy (>=0.2.3,!=0.2.4)", "greenlet (!=0.4.17)"]
-mariadb-connector = ["mariadb (>=1.0.1,!=1.1.2)"]
+asyncmy = ["asyncmy (>=0.2.3,!=0.2.4,!=0.2.6)", "greenlet (!=0.4.17)"]
+mariadb-connector = ["mariadb (>=1.0.1,!=1.1.2,!=1.1.5)"]
 mssql = ["pyodbc"]
 mssql-pymssql = ["pymssql"]
 mssql-pyodbc = ["pyodbc"]
-mypy = ["mypy (>=0.910)", "sqlalchemy2-stubs"]
-mysql = ["mysqlclient (>=1.4.0)", "mysqlclient (>=1.4.0,<2)"]
+mypy = ["mypy (>=0.910)"]
+mysql = ["mysqlclient (>=1.4.0)"]
 mysql-connector = ["mysql-connector-python"]
-oracle = ["cx_oracle (>=7)", "cx_oracle (>=7,<8)"]
+oracle = ["cx_oracle (>=8)"]
+oracle-oracledb = ["oracledb (>=1.0.1)"]
 postgresql = ["psycopg2 (>=2.7)"]
 postgresql-asyncpg = ["asyncpg", "greenlet (!=0.4.17)"]
-postgresql-pg8000 = ["pg8000 (>=1.16.6,!=1.29.0)"]
+postgresql-pg8000 = ["pg8000 (>=1.29.1)"]
+postgresql-psycopg = ["psycopg (>=3.0.7)"]
 postgresql-psycopg2binary = ["psycopg2-binary"]
 postgresql-psycopg2cffi = ["psycopg2cffi"]
-pymysql = ["pymysql", "pymysql (<1)"]
+postgresql-psycopgbinary = ["psycopg[binary] (>=3.0.7)"]
+pymysql = ["pymysql"]
 sqlcipher = ["sqlcipher3_binary"]
 
 [[package]]
-name = "sqlalchemy2-stubs"
-version = "0.0.2a38"
-description = "Typing Stubs for SQLAlchemy 1.4"
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "sqlalchemy2-stubs-0.0.2a38.tar.gz", hash = "sha256:861d722abeb12f13eacd775a9f09379b11a5a9076f469ccd4099961b95800f9e"},
-    {file = "sqlalchemy2_stubs-0.0.2a38-py3-none-any.whl", hash = "sha256:b62aa46943807287550e2033dafe07564b33b6a815fbaa3c144e396f9cc53bcb"},
-]
-
-[package.dependencies]
-typing-extensions = ">=3.7.4"
-
-[[package]]
 name = "sqlmodel"
-version = "0.0.11"
+version = "0.0.16"
 description = "SQLModel, SQL databases in Python, designed for simplicity, compatibility, and robustness."
 optional = false
 python-versions = ">=3.7,<4.0"
 files = [
-    {file = "sqlmodel-0.0.11-py3-none-any.whl", hash = "sha256:bc0d64c4b901d919d2f16bbd79aefb07cb268c29f7c1dd83a84758772ccc95c6"},
-    {file = "sqlmodel-0.0.11.tar.gz", hash = "sha256:fc33abbf7ec29caafabe3d0e1db61e33597857a289e5fd1ecdb91be702b26084"},
+    {file = "sqlmodel-0.0.16-py3-none-any.whl", hash = "sha256:b972f5d319580d6c37ecc417881f6ec4d1ad3ed3583d0ac0ed43234a28bf605a"},
+    {file = "sqlmodel-0.0.16.tar.gz", hash = "sha256:966656f18a8e9a2d159eb215b07fb0cf5222acfae3362707ca611848a8a06bd1"},
 ]
 
 [package.dependencies]
-pydantic = ">=1.9.0,<2.0.0"
-SQLAlchemy = ">=1.4.36,<2.0.0"
-sqlalchemy2-stubs = "*"
+pydantic = ">=1.10.13,<3.0.0"
+SQLAlchemy = ">=2.0.0,<2.1.0"
 
 [[package]]
 name = "starlette"
@@ -3569,4 +3562,4 @@ lexy-transformers = ["openai", "sentence-transformers", "transformers"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "0526d9da9ee775ff10ad80a973e36f8a01311f5cf479b19e144f1508f7a26a0e"
+content-hash = "0f00677cf74b441b93fc76950099e5e7b903de4355357a65be9bf94d1b5323e0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,15 +1,32 @@
 [tool.poetry]
 name = "lexy"
 version = "0.1.0"
-description = ""
+description = "Lexy is a data platform for building AI applications."
 authors = ["Reza Shabani"]
 license = "Apache 2.0"
 readme = "README.md"
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Information Technology",
+    "Intended Audience :: Science/Research",
+    "Intended Audience :: System Administrators",
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Database",
+    "Topic :: Database :: Database Engines/Servers",
+    "Topic :: Software Development :: Libraries",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence"
+]
 
 [tool.poetry.dependencies]
 python = "^3.10"
 fastapi = ">=0.109.0,<1.0.0"
-sqlmodel = "^0.0.11"
+sqlmodel = "^0.0.16"
 pydantic = { version = "^1.10.0", extras = ["email", "dotenv"] }
 python-jose = {version = "^3.3.0", extras = ["cryptography"]}
 passlib = {version = "^1.7.4", extras = ["bcrypt"]}

--- a/sdk-python/lexy_py/binding/client.py
+++ b/sdk-python/lexy_py/binding/client.py
@@ -215,7 +215,7 @@ class BindingClient:
             json_payload["filter"] = None
         r = self.client.patch(f"/bindings/{binding_id}", json=json_payload)
         handle_response(r)
-        return Binding(**r.json(), client=self._lexy_client)
+        return Binding(**r.json()["binding"], client=self._lexy_client)
 
     async def aupdate_binding(self,
                               binding_id: int,
@@ -252,7 +252,7 @@ class BindingClient:
             json_payload["filter"] = None
         r = await self.aclient.patch(f"/bindings/{binding_id}", json=json_payload)
         handle_response(r)
-        return Binding(**r.json(), client=self._lexy_client)
+        return Binding(**r.json()["binding"], client=self._lexy_client)
 
     def delete_binding(self, binding_id: int) -> dict:
         """ Synchronously delete a binding.

--- a/sdk-python/lexy_py_tests/test_binding.py
+++ b/sdk-python/lexy_py_tests/test_binding.py
@@ -2,6 +2,7 @@ import pytest
 
 from lexy_py.client import LexyClient
 from lexy_py.collection.models import Collection
+from lexy_py.filters import FilterBuilder
 from lexy_py.index.models import Index
 from lexy_py.transformer.models import Transformer
 
@@ -12,10 +13,6 @@ class TestBindingClient:
         response = lx_client.get("/")
         assert response.status_code == 200
         assert response.json() == {"Say": "Hello!"}
-
-    def test_bindings(self):
-        # TODO: implement this after setting up mock for testing (do not run against live server)
-        pass
 
     def test_list_bindings(self, lx_client):
         bindings = lx_client.list_bindings()
@@ -77,6 +74,45 @@ class TestBindingClient:
         assert binding.status == "on"
         assert "lexy_index_fields" in binding.transformer_params
         assert set(binding.index.index_fields.keys()) == set(binding.transformer_params["lexy_index_fields"])
+
+        # delete test binding
+        response = lx_client.delete_binding(binding_id=binding.binding_id)
+        assert response == {
+            "msg": "Binding deleted",
+            "binding_id": binding.binding_id
+        }
+
+    def test_update_binding_with_filter(self, lx_client, celery_app, celery_worker):
+        binding = lx_client.create_binding(
+            collection_id="default",
+            index_id="default_text_embeddings",
+            transformer_id="text.embeddings.minilm",
+            description="Test Binding"
+        )
+        assert binding.binding_id is not None
+        assert binding.collection.collection_id == "default"
+        assert binding.index.index_id == "default_text_embeddings"
+        assert binding.transformer.transformer_id == "text.embeddings.minilm"
+        assert binding.description == "Test Binding"
+        assert binding.status == "on"
+        assert "lexy_index_fields" in binding.transformer_params
+        assert set(binding.index.index_fields.keys()) == set(binding.transformer_params["lexy_index_fields"])
+        assert binding.filter is None
+
+        # create filter
+        my_filter = (FilterBuilder().include("meta.size", "less_than", 30000)
+                                    .exclude("meta.type", "in", ["image", "video"]))
+
+        # update binding description and filter
+        binding = lx_client.update_binding(
+            binding_id=binding.binding_id,
+            description="Test Binding with Filter",
+            filters=my_filter
+        )
+        assert binding.binding_id is not None
+        assert binding.description == "Test Binding with Filter"
+        assert binding.filter is not None
+        assert binding.filter == my_filter.to_dict()
 
         # delete test binding
         response = lx_client.delete_binding(binding_id=binding.binding_id)

--- a/sdk-python/lexy_py_tests/test_index.py
+++ b/sdk-python/lexy_py_tests/test_index.py
@@ -61,7 +61,7 @@ class TestIndexClient:
             "index_id": "test_index",
             "index_table_name": "zzidx__test_index",
             "table_dropped": True
-        }
+        }, response
 
     def test_list_indexes(self, lx_client):
         indexes = lx_client.list_indexes()

--- a/sdk-python/lexy_py_tests/test_transformer.py
+++ b/sdk-python/lexy_py_tests/test_transformer.py
@@ -1,5 +1,7 @@
 import pytest
 
+from lexy_py.exceptions import LexyAPIError
+
 
 class TestTransformerClient:
 
@@ -51,3 +53,13 @@ class TestTransformerClient:
         assert 'task_id' in response
         assert isinstance(response["result"], list)
         assert all(isinstance(elem, float) for elem in response["result"])
+
+    def test_create_existing_transformer(self, lx_client):
+        with pytest.raises(LexyAPIError) as exc_info:
+            lx_client.create_transformer(transformer_id="text.embeddings.minilm",
+                                         path="test.tester",
+                                         description="Existing Transformer")
+        assert isinstance(exc_info.value, LexyAPIError)
+        assert exc_info.value.response_data["status_code"] == 400, exc_info.value.response_data
+        assert exc_info.value.response.status_code == 400
+        assert exc_info.value.response.json()["detail"] == "Transformer with that ID already exists"


### PR DESCRIPTION
# What

- Upgrade packages
  + SQLAlchemy to 2.0.28 and SQLModel to 0.0.16
- Update `IndexManager.inspector` to clear cache following [new behavior](https://docs.sqlalchemy.org/en/20/changelog/whatsnew_20.html#behavioral-changes-for-inspector) in `Inspector` class
- Switch from SQLAlchemy's `session.execute()` to SQLModel's `session.exec()` where possible
- Switch from `my_model.dict()` to `my_model.model_dump()` where possible (and to `my_model.model_validate()` in some cases)
- Fixes to `update_binding` endpoint
- Additional tests
  + Binding update and filters
  + Create existing collection and delete collection with documents
  + Create existing transformer
  
# Why

This is the precursor for upgrading to Pydantic 2.x.

# Test plan

- [x] Run `make run-tests` and verify that all tests pass
- [x] Run `examples/tests.ipynb` and verify that there are no errors
- [ ] Run `examples/images.ipynb` and verify that the tutorial works as expected

# Miscellaneous

**NOTE**: While this version works as expected, there are tons of deprecation warnings thrown by SQLModel and FastAPI, which are still using the deprecated methods of SQLModel (none of the warnings are thrown by our code). Many of them should go away upon upgrading to Pydantic 2.x, but if the warning output from tests gets overwhelming we can consider catching it. 

This PR contains some updated packages, so remember to update your local env and docker dev containers.

```shell
# install new dependencies in virtual env
source venv/bin/activate
poetry install --no-root --with test,docs,dev -E "lexy_transformers"

# rebuild docker containers and apply migrations
make update-dev-containers
```
