### PR TITLE
Fix SQLModel validation bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,22 @@
-serve-docs:
+define VENV_ERROR_MESSAGE
+Please activate a virtual environment before running this command.\nFrom the root of project directory, run the following:\n\n$ python3 -m venv venv\n$ source venv/bin/activate\n
+endef
+
+check-virtualenv:
+	@if [ -z "$(VIRTUAL_ENV)" ]; then \
+		echo "$(VENV_ERROR_MESSAGE)"; \
+		exit 1; \
+	fi
+
+check-pyversion:
+	@if [ "$(shell python -c 'import sys; print(sys.version_info >= (3, 11))')" = "False" ]; then \
+		echo "Lexy requires Python 3.11 or higher."; \
+		exit 1; \
+	fi
+
+check-env: check-virtualenv check-pyversion
+
+serve-docs: check-env
 	mkdocs serve -f docs/mkdocs.yml
 
 recreate-queues:
@@ -9,15 +27,45 @@ recreate-queues:
 inspect-celery:
 	docker exec lexy-celeryworker celery inspect active -t 10.0
 
-update-dev-containers:
-	# rebuild lexyserver and lexyworker
-	docker-compose up --build -d --no-deps lexyserver lexyworker
-	# run DB migrations
-	alembic upgrade head
+install-dev: check-env
+	# install poetry
+	pip install poetry
+	# install dev dependencies and extras
+	poetry install --no-root --with test,docs,dev -E "lexy_transformers"
+
+	# install lexy in editable mode
+	pip install -e .
+	pip install -e sdk-python
+
+	# create .env file if it doesn't exist
+	cp -n .env.example .env
+
+build-dev:
+	# build docker images
+	docker-compose up --build -d
+
+update-dev-env: check-env
+	# update dev dependencies and extras
+	poetry update --with test,docs,dev -E "lexy_transformers"
+	# update lexy in editable mode
+	pip install -e .
+	pip install -e sdk-python
 
 restart-dev-containers:
 	docker-compose restart lexyserver lexyworker
 
-run-tests:
+rebuild-dev-containers:
+	# rebuild lexyserver and lexyworker
+	docker-compose up --build -d --no-deps lexyserver lexyworker
+
+run-migrations:
+	# run DB migrations
+	alembic upgrade head
+
+update-dev-containers: rebuild-dev-containers run-migrations
+
+update-dev: update-dev-env update-dev-containers
+
+run-tests: check-env
 	pytest lexy_tests
 	pytest sdk-python

--- a/README.md
+++ b/README.md
@@ -12,28 +12,23 @@ git clone https://github.com/lexy-ai/lexy.git
 
 ### Install dependencies
 
-Python 3.11 or greater is required. 
+Lexy requires Python 3.11 or greater. You can check your Python version by running `python3 --version`.
+
+First create a virtual environment and install the dependencies.
 
 ```Shell
 # create a virtualenv
 python3 -m venv venv 
 source venv/bin/activate
+```
 
-# install poetry
-pip install poetry
+Then run the following to install the dev dependencies and build your docker containers.
 
-# install dev dependencies and extras
-poetry install --no-root --with test,docs,dev -E "lexy_transformers"
-
-# install lexy in editable mode
-pip install -e .
-pip install -e sdk-python
-
-# create .env file if it doesn't exist
-cp -n .env.example .env
-
-# build docker images
-docker-compose up --build -d
+```Shell
+# install dev dependencies
+make install-dev
+# build docker containers
+make build-dev
 ```
 
 ### Where to find services
@@ -68,7 +63,8 @@ Do this before building your docker containers. Or, if you've already run `docke
 following to rebuild the server and worker containers.
 
 ```shell
-docker-compose up --build -d --no-deps lexyserver lexyworker
+# rebuild the server and worker containers
+make rebuild-dev-containers
 ```
 
 ### Run the Dashboard
@@ -81,7 +77,6 @@ To start the dashboard, run:
 cd dashboard
 npm install
 npm run dev
-
 ```
 
 ### PyCharm issues

--- a/docs/docs/faq.md
+++ b/docs/docs/faq.md
@@ -31,7 +31,7 @@ You should add environment variables **before** building your docker containers.
 containers, you can run the following to rebuild the server and worker containers. 
 
 ```bash
-make update-dev-containers
+make rebuild-dev-containers
 ```
 
 Verify that your new environment variable has been added to the server and worker containers.
@@ -58,5 +58,5 @@ are confident that we can optimize performance using C/C++ bindings. And if that
 
 ## I think the name Lexy is super cool.
 
-We agree with you! The name comes from "lexicon," defined as the vocabulary of a person, language, or branch of
+Technically this isn't a question, but we agree with you! The name comes from "lexicon," defined as the vocabulary of a person, language, or branch of
 knowledge.

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-To run Lexy locally, you'll need [Docker](https://www.docker.com/get-started/) installed. You'll also need Python 3. We recommend Python 3.11 or greater.
+To run Lexy locally, you'll need [Docker](https://www.docker.com/get-started/) installed. You'll also need Python 3.11 or greater.
 
 ## Clone the repo
 
@@ -13,33 +13,28 @@ git clone https://github.com/lexy-ai/lexy.git
 
 ### Create a virtual env
 
+First create a virtual environment. Make sure that you're using Python 3.11 or greater. You can check your Python version by running `python3 --version`.
+
 ```Shell
 # create a virtualenv
-python3 -m venv venv
+python3 -m venv venv 
 source venv/bin/activate
 ```
 
-### Install Python dependencies
+### Install dev dependencies
+
+This will also create an `.env` file in the working directory if it doesn't exist already.
+
 ```Shell
-# install poetry
-pip install poetry
-
-# install dev dependencies and extras
-poetry install --no-root --with test,docs,dev -E "lexy_transformers"
-
-# install lexy in editable mode
-pip install -e .
-pip install -e sdk-python
+# install dev dependencies
+make install-dev
 ```
 
-### Build docker images
+### Build docker containers
 
 ```Shell
-# create .env file if it doesn't exist
-cp -n .env.example .env
-
-# build docker images
-docker-compose up --build -d
+# build docker containers
+make build-dev
 ```
 
 ### Configuring AWS
@@ -51,18 +46,48 @@ You'll also need to specify an S3 bucket for file storage (for which your AWS cr
 You can do so by adding `S3_BUCKET=<name-of-your-S3-bucket>` to your `.env` file, or by updating the value of 
 `S3_BUCKET` in `lexy/core/config.py`.
 
+### Using OpenAI transformers
+
+To use OpenAI embeddings in Lexy, you'll need to set the `OPENAI_API_KEY` environment variable. You can do so by adding 
+the following to your `.env` file:
+
+```Shell
+OPENAI_API_KEY=<your-openai-api-key>
+```
+
+Do this before building your docker containers. Or, if you've already run `docker-compose up`, you can run the 
+following to rebuild the server and worker containers.
+
+```shell
+# rebuild the server and worker containers
+make rebuild-dev-containers
+```
+
+### Run the Dashboard (WIP)
+
+Lexy comes with a built-in dashboard to visualize pipelines. This is still under development, but you can run it locally.
+
+To start the dashboard, run:
+
+```shell
+cd dashboard
+npm install
+npm run dev
+```
+
 ## Where to find services
 
 The server will be running at http://localhost:9900. In addition, you can find the following services.
 
 
-| Service      | URL                        | Notes                                                         |
-|--------------|----------------------------|---------------------------------------------------------------|
-| Lexy API     | http://localhost:9900/docs | Swagger API docs                                              |
-| Flower       | http://localhost:5556      | Celery task monitor                                           |
-| RabbitMQ     | http://localhost:15672     | Username: `guest`, Password: `guest`                          |
-| Postgres     | http://localhost:5432      | Database: `lexy`, Username: `postgres`, Password: `postgres`  |
-| Project docs | http://localhost:8000      | Run `make serve-docs`<br/>Username: `lexy`, Password: `guest` |
+| Service        | URL                        | Notes                                                         |
+|----------------|----------------------------|---------------------------------------------------------------|
+| Lexy API       | http://localhost:9900/docs | Swagger API docs                                              |
+| Flower         | http://localhost:5556      | Celery task monitor                                           |
+| RabbitMQ       | http://localhost:15672     | Username: `guest`, Password: `guest`                          |
+| Postgres       | http://localhost:5432      | Database: `lexy`, Username: `postgres`, Password: `postgres`  |
+| Project docs   | http://localhost:8000      | Run `make serve-docs`<br/>Username: `lexy`, Password: `guest` |
+| Lexy Dashboard | http://localhost:3000      | [WIP] Dashboard to show pipelines                             |
 
 
 ## Troubleshooting

--- a/lexy/models/collection.py
+++ b/lexy/models/collection.py
@@ -17,8 +17,11 @@ class CollectionBase(SQLModel):
         default=None,
         primary_key=True,
         min_length=1,
-        max_length=255,
-        regex=r"^[A-Za-z0-9_-]+$"
+        max_length=56,
+        # Postgres identifiers are limited to 63 characters (so 63 - len('zzcol__') = 56)
+        # TODO: switch back to `regex=` (or `pattern=`) once SQLModel bug is fixed
+        #   https://github.com/tiangolo/sqlmodel/discussions/735
+        schema_extra={"pattern": r"^[a-z_][a-z0-9_]{0,55}$"}
     )
     description: Optional[str] = None
     config: Optional[dict[str, Any]] = Field(sa_column=Column(JSONB), default=settings.COLLECTION_DEFAULT_CONFIG)
@@ -36,11 +39,11 @@ class Collection(CollectionBase, table=True):
     )
     documents: list["Document"] = Relationship(
         back_populates="collection",
-        sa_relationship_kwargs={'lazy': 'select'}
+        sa_relationship_kwargs={"lazy": "select"}
     )
     bindings: list["Binding"] = Relationship(
         back_populates="collection",
-        sa_relationship_kwargs={'lazy': 'selectin', 'cascade': 'all, delete-orphan'}
+        sa_relationship_kwargs={"lazy": "selectin", "cascade": "all, delete-orphan"}
     )
 
 

--- a/lexy/models/index.py
+++ b/lexy/models/index.py
@@ -18,8 +18,11 @@ class IndexBase(SQLModel):
         default=None,
         primary_key=True,
         min_length=1,
-        max_length=255,
-        regex=r"^[a-z0-9_-]+$"
+        max_length=56,
+        # Postgres identifiers are limited to 63 characters (so 63 - len('zzidx__') = 56)
+        # TODO: switch back to `regex=` (or `pattern=`) once SQLModel bug is fixed
+        #   https://github.com/tiangolo/sqlmodel/discussions/735
+        schema_extra={"pattern": r"^[a-z_][a-z0-9_]{0,55}$"}
     )
     description: Optional[str] = None
     index_table_schema: Optional[dict[str, Any]] = Field(sa_column=Column(JSON, nullable=False), default={})
@@ -38,11 +41,14 @@ class Index(IndexBase, table=True):
     )
     bindings: list["Binding"] = Relationship(
         back_populates="index",
-        sa_relationship_kwargs={'cascade': 'all, delete-orphan'}
+        sa_relationship_kwargs={"cascade": "all, delete-orphan"}
     )
     index_table_name: str = Field(
         default=None,
-        regex=r"^[a-z0-9_-]+$",
+        # Postgres identifiers are limited to 63 characters
+        # TODO: switch back to `regex=` (or `pattern=`) once SQLModel bug is fixed
+        #   https://github.com/tiangolo/sqlmodel/discussions/735
+        schema_extra={"pattern": r"^[a-z_][a-z0-9_]{0,62}$"},
         sa_column=Column(String, default=default_index_table_name, nullable=False, unique=True),
     )
 

--- a/lexy/models/transformer.py
+++ b/lexy/models/transformer.py
@@ -19,13 +19,17 @@ class TransformerBase(SQLModel):
         primary_key=True,
         min_length=1,
         max_length=255,
-        regex=r"^[a-zA-Z][a-zA-Z0-9_.-]+$"
+        # TODO: switch back to `regex=` (or `pattern=`) once SQLModel bug is fixed
+        #   https://github.com/tiangolo/sqlmodel/discussions/735
+        schema_extra={"pattern": r"^[a-zA-Z][a-zA-Z0-9_.-]+$"}
     )
     path: Optional[str] = Field(
         default=None,
         min_length=1,
         max_length=255,
-        regex=r"^[a-zA-Z][a-zA-Z0-9_.]+$"
+        # TODO: switch back to `regex=` (or `pattern=`) once SQLModel bug is fixed
+        #   https://github.com/tiangolo/sqlmodel/discussions/735
+        schema_extra={"pattern": r"^[a-zA-Z][a-zA-Z0-9_.]+$"}
     )
     description: Optional[str] = None
 

--- a/lexy_tests/test_collection.py
+++ b/lexy_tests/test_collection.py
@@ -79,3 +79,28 @@ class TestCollection:
         assert len(collections) == 1
         assert collections[0].collection_id == "test_collection_validated"
         assert collections[0].description == "Test Collection Validated"
+
+
+class TestCollectionModel:
+
+    def test_create_collection(self):
+        collection = CollectionCreate(collection_id="test_collection")
+        assert collection.collection_id == "test_collection"
+        collection = CollectionCreate(collection_id="_te5t")
+        assert collection.collection_id == "_te5t"
+        collection = CollectionCreate(collection_id="_mytable" * 7)
+        assert collection.collection_id == "_mytable" * 7
+
+    def test_create_collection_with_invalid_id(self):
+        with pytest.raises(ValueError):
+            CollectionCreate(collection_id="", description="Test Collection")  # blank
+        with pytest.raises(ValueError):
+            CollectionCreate(collection_id="test collection", description="Test Collection")  # space
+        with pytest.raises(ValueError):
+            CollectionCreate(collection_id="test-collection", description="Test Collection")  # hyphen
+        with pytest.raises(ValueError):
+            CollectionCreate(collection_id="Test", description="Test Collection")  # uppercase
+        with pytest.raises(ValueError):
+            CollectionCreate(collection_id="1abc", description="Test Collection")  # starts with number
+        with pytest.raises(ValueError):
+            CollectionCreate(collection_id="_mytable" * 8, description="Test Collection")  # too long

--- a/lexy_tests/test_index.py
+++ b/lexy_tests/test_index.py
@@ -88,6 +88,8 @@ class TestIndex:
         index = result.first()
         assert index is None
 
+
+class TestIndexManager:
     # TODO: create fixture for IndexManager and run all relevant tests
     #   - test creating index model
     #   - test creating index table
@@ -96,3 +98,29 @@ class TestIndex:
     #   - test updating index record(s)
     #   - test deleting index record(s)
     #   - test dropping index table
+    pass
+
+
+class TestIndexModel:
+
+    def test_create_index(self):
+        index = IndexCreate(index_id="test_index")
+        assert index.index_id == "test_index"
+        index = IndexCreate(index_id="_te5t")
+        assert index.index_id == "_te5t"
+        index = IndexCreate(index_id="_myindex" * 7)
+        assert index.index_id == "_myindex" * 7
+
+    def test_create_index_with_invalid_id(self):
+        with pytest.raises(ValueError):
+            IndexCreate(index_id="", description="Test Index")  # blank
+        with pytest.raises(ValueError):
+            IndexCreate(index_id="test index", description="Test Index")  # space
+        with pytest.raises(ValueError):
+            IndexCreate(index_id="test-index", description="Test Index")  # hyphen
+        with pytest.raises(ValueError):
+            IndexCreate(index_id="Test", description="Test Index")  # uppercase
+        with pytest.raises(ValueError):
+            IndexCreate(index_id="1abc", description="Test Index")  # starts with number
+        with pytest.raises(ValueError):
+            IndexCreate(index_id="_myindex" * 8, description="Test Index")  # too long

--- a/lexy_tests/test_transformer.py
+++ b/lexy_tests/test_transformer.py
@@ -80,3 +80,26 @@ class TestTransformer:
         )
         transformer = result.first()
         assert transformer is None
+
+
+class TestTransformerModel:
+
+    def test_create_transformer(self):
+        transformer = TransformerCreate(transformer_id="test_transformer")
+        assert transformer.transformer_id == "test_transformer"
+        transformer = TransformerCreate(transformer_id="test-transformer")
+        assert transformer.transformer_id == "test-transformer"
+        transformer = TransformerCreate(transformer_id="test.transformer")
+        assert transformer.transformer_id == "test.transformer"
+
+    def test_create_transformer_with_invalid_id(self):
+        with pytest.raises(ValueError):
+            TransformerCreate(transformer_id="", description="Test Transformer")  # blank
+        with pytest.raises(ValueError):
+            TransformerCreate(transformer_id="test transformer", description="Test Transformer")  # space
+        with pytest.raises(ValueError):
+            TransformerCreate(transformer_id="_test", description="Test Transformer")  # starts with underscore
+        with pytest.raises(ValueError):
+            TransformerCreate(transformer_id="1abc", description="Test Transformer")  # starts with number
+        with pytest.raises(ValueError):
+            TransformerCreate(transformer_id="transformer" * 30, description="Test Transformer")  # too long

--- a/sdk-python/lexy_py/collection/models.py
+++ b/sdk-python/lexy_py/collection/models.py
@@ -14,8 +14,8 @@ class CollectionModel(BaseModel):
     """ Collection model """
     collection_id: str = Field(
         min_length=1,
-        max_length=255,
-        pattern=r"^[a-z0-9_-]+$"
+        max_length=56,
+        pattern="^[a-z_][a-z0-9_]{0,55}$",
     )
     description: Optional[str] = None
     config: Optional[dict[str, Any]] = Field(default={})

--- a/sdk-python/lexy_py/index/models.py
+++ b/sdk-python/lexy_py/index/models.py
@@ -10,7 +10,13 @@ if TYPE_CHECKING:
 
 class IndexModel(BaseModel):
     """ Index model """
-    index_id: str = Field(..., min_length=1, description="The ID of the index.")
+    index_id: str = Field(
+        default=...,
+        min_length=1,
+        max_length=56,
+        pattern="^[a-z_][a-z0-9_]{0,55}$",
+        description="The ID of the index."
+    )
     description: Optional[str] = None
     index_table_schema: Optional[dict[str, Any]] = Field(default={})
     index_fields: Optional[dict[str, Any]] = Field(default={})

--- a/sdk-python/lexy_py/transformer/models.py
+++ b/sdk-python/lexy_py/transformer/models.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 class TransformerModel(BaseModel):
     """ Transformer model """
     transformer_id: str = Field(..., min_length=1, max_length=255, pattern=r"^[a-zA-Z][a-zA-Z0-9_.-]+$")
-    path: Optional[str] = Field(..., min_length=1, max_length=255, pattern=r"^[a-zA-Z][a-zA-Z0-9_.]+$")
+    path: Optional[str] = Field(default=None, min_length=1, max_length=255, pattern=r"^[a-zA-Z][a-zA-Z0-9_.]+$")
     description: Optional[str] = None
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None

--- a/sdk-python/lexy_py_tests/test_collection.py
+++ b/sdk-python/lexy_py_tests/test_collection.py
@@ -124,3 +124,25 @@ class TestCollectionModel:
             collection_without_a_client.list_documents()
         assert isinstance(exc_info.value, ValueError)
         assert str(exc_info.value) == "API client has not been set."
+
+    def test_create_collection(self):
+        collection = Collection(collection_id="test_collection")
+        assert collection.collection_id == "test_collection"
+        collection = Collection(collection_id="_te5t")
+        assert collection.collection_id == "_te5t"
+        collection = Collection(collection_id="_mytable" * 7)
+        assert collection.collection_id == "_mytable" * 7
+
+    def test_create_collection_with_invalid_id(self):
+        with pytest.raises(ValueError):
+            Collection(collection_id="", description="Test Collection")  # blank
+        with pytest.raises(ValueError):
+            Collection(collection_id="test collection", description="Test Collection")  # space
+        with pytest.raises(ValueError):
+            Collection(collection_id="test-collection", description="Test Collection")  # hyphen
+        with pytest.raises(ValueError):
+            Collection(collection_id="Test", description="Test Collection")  # uppercase
+        with pytest.raises(ValueError):
+            Collection(collection_id="1abc", description="Test Collection")  # starts with number
+        with pytest.raises(ValueError):
+            Collection(collection_id="_mytable" * 8, description="Test Collection")  # too long

--- a/sdk-python/lexy_py_tests/test_index.py
+++ b/sdk-python/lexy_py_tests/test_index.py
@@ -2,6 +2,7 @@ import pytest
 
 import lexy_py.document.models
 from lexy_py.exceptions import LexyAPIError, NotFoundError
+from lexy_py.index.models import Index
 
 
 class TestIndexClient:
@@ -138,3 +139,28 @@ class TestIndexClient:
         assert exc_info.value.response_data["status_code"] == 400, exc_info.value.response_data
         assert exc_info.value.response.status_code == 400
         assert exc_info.value.response.text == '{"detail":"Field \'not_a_document_field\' not found in document"}'
+
+
+class TestIndexModel:
+
+    def test_create_index(self):
+        index = Index(index_id="test_index")
+        assert index.index_id == "test_index"
+        index = Index(index_id="_te5t")
+        assert index.index_id == "_te5t"
+        index = Index(index_id="_myindex" * 7)
+        assert index.index_id == "_myindex" * 7
+
+    def test_create_index_with_invalid_id(self):
+        with pytest.raises(ValueError):
+            Index(index_id="", description="Test Index")  # blank
+        with pytest.raises(ValueError):
+            Index(index_id="test index", description="Test Index")  # space
+        with pytest.raises(ValueError):
+            Index(index_id="test-index", description="Test Index")  # hyphen
+        with pytest.raises(ValueError):
+            Index(index_id="Test", description="Test Index")  # uppercase
+        with pytest.raises(ValueError):
+            Index(index_id="1abc", description="Test Index")  # starts with number
+        with pytest.raises(ValueError):
+            Index(index_id="_myindex" * 8, description="Test Index")  # too long

--- a/sdk-python/lexy_py_tests/test_transformer.py
+++ b/sdk-python/lexy_py_tests/test_transformer.py
@@ -1,6 +1,7 @@
 import pytest
 
 from lexy_py.exceptions import LexyAPIError
+from lexy_py.transformer.models import Transformer
 
 
 class TestTransformerClient:
@@ -63,3 +64,26 @@ class TestTransformerClient:
         assert exc_info.value.response_data["status_code"] == 400, exc_info.value.response_data
         assert exc_info.value.response.status_code == 400
         assert exc_info.value.response.json()["detail"] == "Transformer with that ID already exists"
+
+
+class TestTransformerModel:
+
+    def test_create_transformer(self):
+        transformer = Transformer(transformer_id="test_transformer")
+        assert transformer.transformer_id == "test_transformer"
+        transformer = Transformer(transformer_id="test-transformer")
+        assert transformer.transformer_id == "test-transformer"
+        transformer = Transformer(transformer_id="test.transformer")
+        assert transformer.transformer_id == "test.transformer"
+
+    def test_create_transformer_with_invalid_id(self):
+        with pytest.raises(ValueError):
+            Transformer(transformer_id="", description="Test Transformer")  # blank
+        with pytest.raises(ValueError):
+            Transformer(transformer_id="test transformer", description="Test Transformer")  # space
+        with pytest.raises(ValueError):
+            Transformer(transformer_id="_test", description="Test Transformer")  # starts with underscore
+        with pytest.raises(ValueError):
+            Transformer(transformer_id="1abc", description="Test Transformer")  # starts with number
+        with pytest.raises(ValueError):
+            Transformer(transformer_id="transformer" * 30, description="Test Transformer")  # too long


### PR DESCRIPTION
# What

- Fixed some validation bugs caused by [regex in SQLModel](https://github.com/tiangolo/sqlmodel/discussions/735)
- Updated requirements for `Collection.collection_id` and `Index.index_id` fields
- Updated Makefile with additional commands
- Updated documentation
- Additional tests

# Why

Indexes with mixed case identifiers resulted in Postgres name mismatch, and the objects were not found by SQLAlchemy.


# Test plan

- [x] Run `make run-tests` and verify that all tests pass
- [x] Run `examples/tests.ipynb` and verify that there are no errors
- [x] Run `examples/images.ipynb` and verify that the tutorial works as expected
