### PR TITLE
Bugfix for seed binding without default collection

### DIFF
--- a/lexy/db/init_db.py
+++ b/lexy/db/init_db.py
@@ -52,7 +52,11 @@ def add_default_data_to_db(session=db):
             c = session.query(models.Collection).filter(
                 models.Collection.collection_name == b["collection_name"]
             ).first()
-            session.add(models.Binding(**b, collection_id=c.collection_id))
+            if c:
+                session.add(models.Binding(**b, collection_id=c.collection_id))
+            else:
+                logger.warning(f"Collection '{b['collection_name']}' not found for binding "
+                               f"'{b['binding_name']}' - skipping binding")
         session.commit()
 
 


### PR DESCRIPTION
# What

Bugfix for seed data without default collection.

# Why

Deleting default collection causes a crash loop in adding the binding in seed data.

# Test plan

- [ ] Run `make run-tests` and verify that all tests pass
- [ ] Run `examples/tests.ipynb` and verify that there are no errors
- [ ] Run `examples/images.ipynb` and verify that the tutorial works as expected
