### PR TITLE
Add GCS as a storage backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,8 +10,10 @@
 # SECRET_KEY=changethis  # change this! you can generate a new one with `openssl rand -hex 32`
 # FIRST_SUPERUSER_EMAIL=lexy@lexy.ai  # change this!
 # FIRST_SUPERUSER_PASSWORD=lexy  # change this!
-# S3_BUCKET=your_s3_bucket_name
+# DEFAULT_STORAGE_SERVICE=s3
+# DEFAULT_STORAGE_BUCKET=your_bucket_name
 # PIPELINE_DIR=./pipelines  # relative to the project root - the '.' is required
+# GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account-credentials.json
 
 # Other secrets
 # OPENAI_API_KEY=your_secret_key

--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ In order to upload and store files to Lexy, you'll need to configure AWS. You ca
 put `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` in your `.env` file.
 
 You'll also need to specify an S3 bucket for file storage (for which your AWS credentials should have full access). 
-You can do so by adding `S3_BUCKET=<name-of-your-S3-bucket>` to your `.env` file, or by updating the value of 
-`s3_bucket` in `lexy/core/config.py`.
+You can do so by adding `DEFAULT_STORAGE_BUCKET=<name-of-your-S3-bucket>` to your `.env` file. Remember to rebuild your 
+dev containers for the change to take effect (run `make rebuild-dev-containers` on the command line).
 
 ### Using OpenAI transformers
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -23,13 +23,18 @@ services:
       - CELERY_BROKER_URL=amqp://guest:guest@queue:5672//
       - CELERY_RESULT_BACKEND=db+postgresql://postgres:postgres@db_postgres/lexy
       - OPENAI_API_KEY=${OPENAI_API_KEY}
-      - S3_BUCKET=${S3_BUCKET}
-      - PIPELINE_DIR=${PIPELINE_DIR:-./pipelines}
+      - PIPELINE_DIR=/home/app/pipelines
       - PYTHONPATH=/home/app:/home/app/pipelines
+      - GOOGLE_APPLICATION_CREDENTIALS=/run/secrets/gcp_credentials
     volumes:
       - ./:/home/app
       - ${PIPELINE_DIR:-./pipelines}:/home/app/pipelines
+      # Uncomment the following line if you are using AWS credentials
       - $HOME/.aws/credentials:/root/.aws/credentials:ro
+      # Uncomment the following line if you are using Google Cloud with application-default credentials
+      #- $HOME/.config/gcloud:/root/.config/gcloud:ro
+    secrets:
+      - gcp_credentials
     networks:
       - lexy-net
 
@@ -107,18 +112,24 @@ services:
       - POSTGRES_PASSWORD=postgres
       - POSTGRES_DB=lexy
       - POSTGRES_HOST=db_postgres
-      - PIPELINE_DIR=${PIPELINE_DIR:-./pipelines}
+      - PIPELINE_DIR=/home/app/pipelines
       - PYTHONPATH=/home/app:/home/app/pipelines
+      # Unset GOOGLE_APPLICATION_CREDENTIALS for the celery worker
+      - GOOGLE_APPLICATION_CREDENTIALS=
     volumes:
       - ./:/home/app
       - ${PIPELINE_DIR:-./pipelines}:/home/app/pipelines
     networks:
       - lexy-net
 
-
 volumes:
   db-postgres:
     driver: local
+
+secrets:
+  # Google Cloud service account credentials
+  gcp_credentials:
+    file: ${GOOGLE_APPLICATION_CREDENTIALS:-null}
 
 networks:
   lexy-net:

--- a/docs/docs/faq.md
+++ b/docs/docs/faq.md
@@ -14,7 +14,8 @@ Then open the `.env` file and add your new environment variable.
 ```shell title=".env" hl_lines="7"
 # Lexy settings
 SECRET_KEY=super_secret_key
-S3_BUCKET=s3_bucket_name
+DEFAULT_STORAGE_SERVICE=s3
+DEFAULT_STORAGE_BUCKET=your_s3_bucket_name
 
 # Other secrets
 OPENAI_API_KEY=your_secret_api_key

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -43,8 +43,8 @@ In order to upload and store files to Lexy, you'll need to configure AWS. You ca
 put `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` in your `.env` file.
 
 You'll also need to specify an S3 bucket for file storage (for which your AWS credentials should have full access). 
-You can do so by adding `S3_BUCKET=<name-of-your-S3-bucket>` to your `.env` file, or by updating the value of 
-`S3_BUCKET` in `lexy/core/config.py`.
+You can do so by adding `DEFAULT_STORAGE_BUCKET=<name-of-your-S3-bucket>` to your `.env` file. Remember to rebuild your 
+dev containers for the change to take effect (run `make rebuild-dev-containers` on the command line).
 
 ### Using OpenAI transformers
 

--- a/examples/tests.ipynb
+++ b/examples/tests.ipynb
@@ -3,7 +3,14 @@
   {
    "cell_type": "markdown",
    "source": [
-    "# Lexy client"
+    "# Lexy client\n",
+    "\n",
+    "**WARNING**: The tests in this notebook run against the development API and database. To run isolated tests, use the following shell command instead.\n",
+    "\n",
+    "\n",
+    "```bash\n",
+    "make run-tests\n",
+    "```"
    ],
    "metadata": {
     "collapsed": false
@@ -440,6 +447,18 @@
    "execution_count": null,
    "outputs": [],
    "source": [
+    "# uploaded image document\n",
+    "img_docs[0].model_dump()"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
     "# upload image documents in batches\n",
     "more_img_docs = junk_files_collection.upload_documents(\n",
     "    files=[\n",
@@ -490,6 +509,42 @@
    "outputs": [],
    "source": [
     "assert len(even_more_docs) == 3"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# uploaded PDF document\n",
+    "even_more_docs[0].model_dump()"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# uploaded video document\n",
+    "even_more_docs[1].model_dump()"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# uploaded text document\n",
+    "even_more_docs[2].model_dump()"
    ],
    "metadata": {
     "collapsed": false

--- a/lexy/api/endpoints/collections.py
+++ b/lexy/api/endpoints/collections.py
@@ -1,7 +1,6 @@
 from io import BytesIO
 from typing import Union
 
-import boto3
 from fastapi import APIRouter, Depends, HTTPException, Query, status, UploadFile
 from PIL import Image
 from sqlmodel import delete, exists, select
@@ -12,8 +11,8 @@ from lexy.db.session import get_session
 from lexy.storage.client import (
     construct_key_for_document,
     construct_key_for_thumbnail,
-    get_s3_client,
-    upload_file_to_s3
+    get_storage_client,
+    StorageClient
 )
 from lexy.models.collection import Collection, CollectionCreate, CollectionUpdate
 from lexy.models.document import Document, DocumentCreate
@@ -242,11 +241,15 @@ async def add_collection_documents(collection_id: str,
 async def upload_collection_documents(collection_id: str,
                                       files: list[UploadFile],
                                       session: AsyncSession = Depends(get_session),
-                                      s3_client: boto3.client = Depends(get_s3_client)) -> list[dict]:
+                                      storage_client: StorageClient = Depends(get_storage_client)) -> list[dict]:
     # get the collection
     collection = await crud.get_collection_by_id(session=session, collection_id=collection_id)
     if not collection:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Collection not found")
+    # TODO: get storage client from collection config
+    # storage_client = get_storage_client(service=collection.config.get('storage_service', None))
+    storage_bucket = collection.config.get('storage_bucket', settings.DEFAULT_STORAGE_BUCKET)
+    storage_prefix = collection.config.get('storage_prefix', None)
 
     docs_uploaded = []
 
@@ -255,17 +258,23 @@ async def upload_collection_documents(collection_id: str,
         file_dict = {
             "content_type": file.content_type,
             "filename": file.filename,
-            "size": file.size,
-            # "headers": file.headers,  # headers seem to be redundant
+            "size": file.size
         }
 
-        s3_bucket = settings.S3_BUCKET
         # TODO: replace file.filename with the unique document id - will require saving the document in the DB first
         #  but for now, we're using the filename as the document_id, which is equivalent to the following:
-        #    s3_key = f"collections/{collection_id}/documents/{file.filename}"
+        #    document_key = f"collections/{collection_id}/documents/{file.filename}"
         # uncomment the following line when ready
-        # s3_document_key = await construct_key_for_document(document=document, filename=file.filename)
-        s3_document_key = await construct_key_for_document(collection_id=collection_id, document_id=file.filename)
+        # document_key = await construct_key_for_document(
+        #     document=document,
+        #     path_prefix=storage_prefix,
+        #     filename=file.filename
+        # )
+        document_key = await construct_key_for_document(
+            collection_id=collection_id,
+            document_id=file.filename,
+            path_prefix=storage_prefix
+        )
 
         # TODO: move this to a separate parsing function - don't read into memory if not parsing
         file_content = await file.read()
@@ -317,18 +326,22 @@ async def upload_collection_documents(collection_id: str,
 
             # generate thumbnails
             if collection.config.get('generate_thumbnails') and collection.config.get('store_files'):
-                # generate thumbnails and upload to S3
+                # generate thumbnails and upload to storage
                 thumbnails = {}
                 for dims in settings.IMAGE_THUMBNAIL_SIZES:
-                    s3_thumbnail_key = await construct_key_for_thumbnail(dims=dims, collection_id=collection_id,
-                                                                         document_id=file.filename)
+                    thumbnail_key = await construct_key_for_thumbnail(
+                        dims=dims,
+                        collection_id=collection_id,
+                        document_id=file.filename,
+                        path_prefix=storage_prefix
+                    )
                     img_copy = img.copy()
                     img_copy.thumbnail(dims, Image.Resampling.LANCZOS)
                     img_byte_arr = BytesIO()
                     img_copy.save(img_byte_arr, format=img.format or 'JPEG')
-                    # Note: img_byte_arr.seek(0) is run in upload_file_to_s3 by default `rewind=True`
-                    s3_thumbnail_meta = upload_file_to_s3(img_byte_arr, s3_client, s3_bucket, s3_thumbnail_key)
-                    thumbnails[f"{dims[0]}x{dims[1]}"] = s3_thumbnail_meta
+                    # Note: img_byte_arr.seek(0) is run in storage_client.upload_object by default `rewind=True`
+                    storage_thumbnail_meta = storage_client.upload_object(img_byte_arr, storage_bucket, thumbnail_key)
+                    thumbnails[f"{dims[0]}x{dims[1]}"] = storage_thumbnail_meta
                 file_dict["image"]["thumbnails"] = thumbnails
         elif file.content_type == 'application/vnd.openxmlformats-officedocument.wordprocessingml.document':
             # # example processing for docx
@@ -338,10 +351,10 @@ async def upload_collection_documents(collection_id: str,
             # num_tables = len(doc.tables)
             pass
 
-        # Upload the file to S3
+        # Upload the file to storage
         if collection.config.get('store_files'):
-            s3_meta = upload_file_to_s3(file.file, s3_client, s3_bucket, s3_document_key)
-            file_dict.update(s3_meta)
+            storage_document_meta = storage_client.upload_object(file_in_memory, storage_bucket, document_key)
+            file_dict.update(storage_document_meta)
 
         document = Document(content=doc_content, meta=file_dict, collection_id=collection_id)
         session.add(document)
@@ -349,7 +362,7 @@ async def upload_collection_documents(collection_id: str,
         await session.refresh(document)
 
         # generate tasks
-        tasks = await generate_tasks_for_document(document, s3_client=s3_client)
+        tasks = await generate_tasks_for_document(document, storage_client=storage_client)
         file_dict["document"] = document
         file_dict["tasks"] = tasks
 

--- a/lexy/api/endpoints/utils.py
+++ b/lexy/api/endpoints/utils.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import time
 
 from fastapi import APIRouter, status
@@ -109,3 +110,10 @@ async def get_index_manager_from_celery() -> dict:
         (model, index_manager.index_models[model].__table__.name) for model in index_manager.index_models
     )
     return {"index_models_and_tables": index_models_and_tables}
+
+
+@router.get("/os-env",
+            status_code=status.HTTP_200_OK,
+            name="os_env")
+async def os_env():
+    return dict(os.environ)

--- a/lexy/core/config.py
+++ b/lexy/core/config.py
@@ -1,11 +1,19 @@
 import importlib
+import logging
 import os
 import pkgutil
+import sys
+from functools import lru_cache
 from pathlib import Path
-from typing import Optional
+from typing import Literal, Optional
 
-from pydantic import DirectoryPath, field_validator, EmailStr, Field, SecretStr
+from pydantic import DirectoryPath, field_validator, EmailStr, Field, SecretStr, ValidationInfo
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+# For some reason, this statement initializes logging for the rest of the application.
+#  Without it, we don't get log statements for IndexManager.
+logging.info("Loading config.py")
 
 
 def get_transformer_modules(transformer_pkg: str = 'lexy.transformers'):
@@ -67,11 +75,36 @@ class AppSettings(BaseSettings):
     AWS_REGION: Optional[str] = Field(default=None, validation_alias="AWS_REGION")
     S3_BUCKET: Optional[str] = Field(default=None, validation_alias="S3_BUCKET")
 
+    # Google Cloud settings
+    # Path to a file containing JSON credentials for a service account. Using Optional[str] because setting to
+    #  Optional[FilePath] triggers a validation error if GOOGLE_APPLICATION_CREDENTIALS is an empty string.
+    GOOGLE_APPLICATION_CREDENTIALS: Optional[str] = Field(default=None,
+                                                          validation_alias="GOOGLE_APPLICATION_CREDENTIALS")
+
+    # Storage settings
+    DEFAULT_STORAGE_SERVICE: Optional[Literal['s3', 'gcs']] = (
+        Field(default="s3", validation_alias="DEFAULT_STORAGE_SERVICE")
+    )
+    DEFAULT_STORAGE_BUCKET: Optional[str] = Field(default=None, validation_alias="DEFAULT_STORAGE_BUCKET")
+    DEFAULT_STORAGE_PREFIX: Optional[str] = Field(default=None, validation_alias="DEFAULT_STORAGE_PREFIX")
+
     # Default config for Collection objects and images
     COLLECTION_DEFAULT_CONFIG: dict = {
         'store_files': True,
-        'generate_thumbnails': True,
+        'generate_thumbnails': True
     }
+
+    @field_validator('COLLECTION_DEFAULT_CONFIG')
+    def set_collection_default_config(cls, v: dict, info: ValidationInfo) -> dict:
+        if v.get('store_files') is True:
+            if not v.get('storage_service'):
+                v['storage_service'] = info.data.get('DEFAULT_STORAGE_SERVICE')
+            if not v.get('storage_bucket'):
+                v['storage_bucket'] = info.data.get('DEFAULT_STORAGE_BUCKET')
+            if not v.get('storage_prefix'):
+                v['storage_prefix'] = info.data.get('DEFAULT_STORAGE_PREFIX')
+        return v
+
     IMAGE_THUMBNAIL_SIZES: set[tuple] = {
         # (100, 100),
         (200, 200),
@@ -127,28 +160,36 @@ class AppSettings(BaseSettings):
         #     return expand_transformer_imports(expanded_set)
         return expand_transformer_imports(self.LEXY_WORKER_TRANSFORMER_IMPORTS)
 
-    @field_validator('SECRET_KEY')
-    @classmethod
-    def check_secret_key(cls, value):
-        if value.get_secret_value() == "changethis":
-            import logging
-            logging.warning("Using default value of SECRET_KEY. Do NOT use this value for production!")
-        return value
-
     @field_validator('PIPELINE_DIR', mode='before')
     @classmethod
     def check_pipeline_dir(cls, value):
-        # override if inside of docker
-        # TODO: Move this jank override to a proper env setup
-        if os.getenv("DOCKER", False):
-            value = "pipelines"
         if value:
             pipeline_dir = Path(value).resolve()
             if not pipeline_dir.is_dir():
                 raise ValueError(f"Pipeline directory '{pipeline_dir}' does not exist.")
+            # log a warning if pipeline_dir is not in the Python path (Celery can't import pipelines)
+            if str(pipeline_dir) not in sys.path and str(pipeline_dir) != os.getcwd():
+                logging.warning(f"Pipeline directory '{pipeline_dir}' is not in the Python path. "
+                                f"Your pipelines may not be imported correctly.")
         return value
 
     model_config = SettingsConfigDict(case_sensitive=True, env_file='.env', env_file_encoding='utf-8', extra="allow")
+
+
+class DevelopmentAppSettings(AppSettings):
+    pass
+
+
+class ProductionAppSettings(AppSettings):
+
+    @field_validator('SECRET_KEY')
+    @classmethod
+    def check_secret_key(cls, value):
+        if value.get_secret_value() == "changethis":
+            logging.error("Using default value of SECRET_KEY in production settings! "
+                          "Change this value to a secure secret key.")
+            raise Exception("Using default value of SECRET_KEY in production settings!")
+        return value
 
 
 class TestAppSettings(AppSettings):
@@ -162,5 +203,21 @@ class TestAppSettings(AppSettings):
     FIRST_SUPERUSER_EMAIL: EmailStr = Field("test@lexy.ai", validation_alias="TEST_SUPERUSER_EMAIL")
     FIRST_SUPERUSER_PASSWORD: SecretStr = Field("test", validation_alias="TEST_SUPERUSER_PASSWORD")
 
+    # Storage settings
+    DEFAULT_STORAGE_PREFIX: Optional[str] = Field(default="lexy_tests", validation_alias="DEFAULT_STORAGE_PREFIX")
+    S3_TEST_BUCKET: Optional[str] = Field(default=None, validation_alias="S3_TEST_BUCKET")
+    GCS_TEST_BUCKET: Optional[str] = Field(default=None, validation_alias="GCS_TEST_BUCKET")
 
-settings = AppSettings()
+
+@lru_cache()
+def get_settings():
+    config_cls_dict = {
+        "development": DevelopmentAppSettings,
+        "testing": TestAppSettings,
+    }
+    config_name = os.environ.get("LEXY_CONFIG", "development")
+    config_cls = config_cls_dict[config_name]
+    return config_cls()
+
+
+settings = get_settings()

--- a/lexy/storage/__init__.py
+++ b/lexy/storage/__init__.py
@@ -1,31 +1,45 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
+from typing import Literal
 from urllib.parse import parse_qs, urlparse
 
 
-def presigned_url_is_expired(url, storage_service: str = 's3') -> bool:
+def presigned_url_is_expired(url: str, storage_service: str = 's3') -> bool:
     if storage_service == 's3':
-        return s3_presigned_url_is_expired(url)
-    elif storage_service == 'azure':
-        raise NotImplementedError
+        return signed_url_is_expired(url, svc='Amz')
     elif storage_service == 'gcs':
+        return signed_url_is_expired(url, svc='Goog')
+    elif storage_service == 'azure':
         raise NotImplementedError
     else:
         raise ValueError(f'Unsupported storage service: {storage_service} - '
-                         f'must be one of the following: s3, azure, gcs')
+                         f'must be one of the following: s3, gcs, azure')
 
 
-def s3_presigned_url_is_expired(url) -> bool:
-    query = parse_qs(urlparse(url).query)
-    if 'X-Amz-Expires' in query:
-        expiration = query['X-Amz-Expires'][0]
-        expiration = int(expiration)
-        expiration = timedelta(seconds=expiration)
-        expiration = datetime.now() + expiration
-        return expiration < datetime.now()
-    elif 'Expires' in query:
-        expiration = query['Expires'][0]
-        expiration = int(expiration)
-        expiration = datetime.fromtimestamp(expiration)
-        return expiration < datetime.now()
+def signed_url_is_expired(url: str, svc: Literal['Amz', 'Goog']):
+    """Checks if a signed URL (V2 or V4) has expired.
+
+    Args:
+        url (str): The signed URL string.
+        svc (Literal['Amz', 'Goog']): The service query parameter used to check for expiration in V4 signatures.
+            Either 'Amz' for AWS or 'Goog' for GCP.
+
+    Returns:
+        True if the signed URL is expired, False otherwise.
+
+    Raises:
+        ValueError: If no expiration found in signed url.
+    """
+    query_params = parse_qs(urlparse(url).query)
+    # V4 signature
+    if f'X-{svc}-Expires' in query_params:
+        expires_in = int(query_params[f'X-{svc}-Expires'][0])
+        issued_at_dt = datetime.fromisoformat(query_params[f'X-{svc}-Date'][0])
+        expires_at_dt = issued_at_dt + timedelta(seconds=expires_in)
+        return expires_at_dt < datetime.now(tz=timezone.utc)
+    # V2 signature
+    elif 'Expires' in query_params:
+        expires_at = int(query_params['Expires'][0])
+        expires_at_dt = datetime.fromtimestamp(expires_at, tz=timezone.utc)
+        return expires_at_dt < datetime.now(tz=timezone.utc)
     else:
-        raise ValueError('No expiration found in presigned url')
+        raise ValueError('No expiration found in signed url')

--- a/lexy/storage/base.py
+++ b/lexy/storage/base.py
@@ -1,0 +1,21 @@
+from abc import ABC, abstractmethod
+
+
+class StorageClient(ABC):
+    """Abstract base class for storage clients."""
+
+    @abstractmethod
+    def list_buckets(self) -> list[str]:
+        pass
+
+    @abstractmethod
+    def upload_object(self, fileobj, bucket_name: str, object_name: str, rewind: bool = True) -> dict:
+        pass
+
+    @abstractmethod
+    def generate_presigned_url(self, bucket_name: str, object_name: str, expiration: int = 3600) -> str:
+        pass
+
+    @abstractmethod
+    def delete_object(self, bucket_name: str, object_name: str) -> None:
+        pass

--- a/lexy/storage/client.py
+++ b/lexy/storage/client.py
@@ -1,31 +1,32 @@
-from typing import TYPE_CHECKING
-
-import boto3
+from typing import TYPE_CHECKING, Union
 
 from lexy.core.config import settings
+from lexy.storage.base import StorageClient
+from lexy.storage.gcs import GCSClient
+from lexy.storage.s3 import S3Client
 
 if TYPE_CHECKING:
-    from lexy.models.document import Document
+    from lexy.models.document import Document, DocumentBase
 
 
-async def get_s3_client() -> boto3.client:
-    client_kwargs = {}
-    if settings.AWS_ACCESS_KEY_ID and settings.AWS_SECRET_ACCESS_KEY:
-        client_kwargs["aws_access_key_id"] = settings.AWS_ACCESS_KEY_ID
-        client_kwargs["aws_secret_access_key"] = settings.AWS_SECRET_ACCESS_KEY.get_secret_value()
-    if settings.AWS_REGION:
-        client_kwargs["region_name"] = settings.AWS_REGION
-    return boto3.client('s3', **client_kwargs)
+# TODO: Move this to lexy.api.deps?
+async def get_storage_client() -> StorageClient:
+    if settings.DEFAULT_STORAGE_SERVICE == "s3":
+        return S3Client()
+    elif settings.DEFAULT_STORAGE_SERVICE == "gcs":
+        return GCSClient()
+    else:
+        raise ValueError("Unsupported storage service configured")
 
 
-def generate_presigned_urls_for_document(document: "Document",
-                                         s3_client: boto3.client = None,
-                                         expiration: int = 3600) -> dict:
-    """ Generate presigned URLs for a document.
+def generate_signed_urls_for_document(document: Union["Document", "DocumentBase"],
+                                      storage_client: StorageClient,
+                                      expiration: int = 3600) -> dict:
+    """ Generate signed URLs for a document.
 
     Args:
         document (Document): The document object.
-        s3_client: The S3 client.
+        storage_client (StorageClient): The storage client.
         expiration (int): The number of seconds the presigned URLs are valid for. Default is 3600 seconds (1 hour).
 
     Returns:
@@ -35,7 +36,7 @@ def generate_presigned_urls_for_document(document: "Document",
         >>> from lexy_py import LexyClient
         >>> lx = LexyClient()
         >>> my_image_document = lx.list_documents(collection_name='my_image_collection', limit=1)[0]
-        >>> generate_presigned_urls_for_document(my_image_document, s3_client=s3_client)
+        >>> generate_signed_urls_for_document(my_image_document, storage_client=storage_client)
         {
             "object": "https://my-bucket.s3.amazonaws.com/path/to/object?...",
             "thumbnails": {
@@ -43,7 +44,7 @@ def generate_presigned_urls_for_document(document: "Document",
             }
         }
         >>> my_pdf_document = lx.list_documents(collection_name='pdf_collection', limit=1)[0]
-        >>> generate_presigned_urls_for_document(my_pdf_document, s3_client=s3_client)
+        >>> generate_signed_urls_for_document(my_pdf_document, storage_client=storage_client)
         {
             "object": "https://my-bucket.s3.amazonaws.com/path/to/object?...",
         }
@@ -53,27 +54,27 @@ def generate_presigned_urls_for_document(document: "Document",
     # url for the document object
     if document.meta.get('s3_bucket') and document.meta.get('s3_key'):
         presigned_urls["object"] = (
-            s3_client.generate_presigned_url('get_object',
-                                             Params={'Bucket': document.meta['s3_bucket'],
-                                                     'Key': document.meta['s3_key']},
-                                             ExpiresIn=expiration))
+            storage_client.generate_presigned_url(bucket_name=document.meta.get('s3_bucket'),
+                                                  object_name=document.meta.get('s3_key'),
+                                                  expiration=expiration)
+        )
 
     # urls for thumbnails
     if document.meta.get('image') and document.meta.get('image').get('thumbnails'):
         presigned_urls["thumbnails"] = {}
         for dims, vals in document.meta.get('image').get('thumbnails').items():
             presigned_urls["thumbnails"][dims] = (
-                s3_client.generate_presigned_url('get_object',
-                                                 Params={'Bucket': vals.get('s3_bucket'),
-                                                         'Key': vals.get('s3_key')},
-                                                 ExpiresIn=expiration))
+                storage_client.generate_presigned_url(bucket_name=vals.get('s3_bucket'),
+                                                      object_name=vals.get('s3_key'),
+                                                      expiration=expiration)
+            )
 
     return presigned_urls
 
 
 async def construct_key_for_document(document: "Document" = None, collection_id: str = None, document_id: str = None,
                                      path_prefix: str = None, filename: str = None) -> str:
-    """ Construct an S3 key for a document.
+    """ Construct a storage key (object name) for a document.
 
     Args:
         document (Document): The document object.
@@ -83,7 +84,7 @@ async def construct_key_for_document(document: "Document" = None, collection_id:
         filename (str): The filename.
 
     Returns:
-        str: The S3 key.
+        str: The storage key (object name).
 
     Raises:
         ValueError: If neither a document object nor collection_id and document_id are provided.
@@ -116,7 +117,7 @@ async def construct_key_for_document(document: "Document" = None, collection_id:
 
 async def construct_key_for_thumbnail(dims: tuple[int, int], document: "Document" = None, collection_id: str = None,
                                       document_id: str = None, path_prefix: str = None, filename: str = None) -> str:
-    """ Construct an S3 key for thumbnails of a document.
+    """ Construct a storage key (object name) for thumbnails of a document.
 
     Args:
         dims (tuple[int, int]): The dimensions of the thumbnail.
@@ -127,7 +128,7 @@ async def construct_key_for_thumbnail(dims: tuple[int, int], document: "Document
         filename (str): The filename.
 
     Returns:
-        str: The S3 key.
+        str: The storage key (object name).
 
     Raises:
         ValueError: If neither a document object nor collection_id and document_id are provided.
@@ -141,8 +142,8 @@ async def construct_key_for_thumbnail(dims: tuple[int, int], document: "Document
         >>> construct_key_for_thumbnail(dims=(200, 200), collection_id='423c718b', document_id='123456')
         'collections/423c718b/thumbnails/200x200/123456'
         >>> construct_key_for_thumbnail(dims=(150, 150), collection_id='423c718b',
-        ...                             document_id='123456', filename='thumb.jpg')
-        'collections/423c718b/thumbnails/150x150/123456/thumb.jpg'
+        ...                             document_id='123456', filename='thumbnail.jpg')
+        'collections/423c718b/thumbnails/150x150/123456/thumbnail.jpg'
         >>> construct_key_for_thumbnail(dims=(200, 200), document=my_image_document, path_prefix='public')
         'public/collections/423c718b/thumbnails/200x200/123456'
     """
@@ -159,27 +160,3 @@ async def construct_key_for_thumbnail(dims: tuple[int, int], document: "Document
     if filename:
         key = f"{key}/{filename}"
     return key
-
-
-def upload_file_to_s3(file, s3_client: boto3.client, s3_bucket: str, s3_key: str, rewind: bool = True) -> dict:
-    """ Upload a file to S3.
-
-    Args:
-        file: The file to upload.
-        s3_client (boto3.client): The S3 client.
-        s3_bucket (str): The name of the S3 bucket.
-        s3_key (str): The S3 key for the file.
-        rewind (bool): Whether to rewind the file object before uploading. Default is True.
-
-    Returns:
-        Dict: A dictionary containing the S3 bucket, key, URL, and URI.
-    """
-    if rewind:
-        file.seek(0)
-    s3_client.upload_fileobj(file, s3_bucket, s3_key)
-    return {
-        "s3_bucket": s3_bucket,
-        "s3_key": s3_key,
-        "s3_url": f"https://{s3_bucket}.s3.amazonaws.com/{s3_key}",
-        "s3_uri": f"s3://{s3_bucket}/{s3_key}",
-    }

--- a/lexy/storage/gcs.py
+++ b/lexy/storage/gcs.py
@@ -1,0 +1,56 @@
+import datetime
+import logging
+
+from google.cloud import storage
+from google.oauth2 import service_account
+
+from lexy.core.config import settings
+from lexy.storage.base import StorageClient
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+
+class GCSClient(StorageClient):
+
+    def __init__(self, credentials_file: str = settings.GOOGLE_APPLICATION_CREDENTIALS, **kwargs):
+        if credentials_file:
+            logger.info(f"Creating GCS client using credentials file: {credentials_file}")
+            credentials = service_account.Credentials.from_service_account_file(credentials_file)
+        else:
+            logger.warning("Missing `credentials_file` - creating GCS client using default credentials. "
+                           "You will not be able to sign URLs with this client.")
+            credentials = None
+        self.client = storage.Client(credentials=credentials, **kwargs)
+
+    def list_buckets(self) -> list[str]:
+        buckets = self.client.list_buckets()
+        return [bucket.name for bucket in buckets]
+
+    def upload_object(self, fileobj, bucket_name: str, object_name: str, rewind: bool = True) -> dict:
+        bucket = self.client.bucket(bucket_name)
+        blob: storage.blob.Blob = bucket.blob(object_name)
+        if isinstance(fileobj, str):
+            blob.upload_from_filename(fileobj)
+        else:
+            blob.upload_from_file(fileobj, rewind=rewind)
+        # FIXME: refactor
+        return {
+            "storage_service": "gcs",
+            "s3_bucket": bucket_name,
+            "s3_key": object_name,
+            # "s3_url": f"https://storage.googleapis.com/{bucket_name}/{object_name}",
+            # "s3_uri": f"gs://{bucket_name}/{object_name}",
+        }
+
+    def generate_presigned_url(self, bucket_name: str, object_name: str, expiration: int = 3600) -> str:
+        bucket = self.client.bucket(bucket_name)
+        blob: storage.blob.Blob = bucket.blob(object_name)
+        url = blob.generate_signed_url(expiration=datetime.timedelta(seconds=expiration),
+                                       version="v4")
+        return url
+
+    def delete_object(self, bucket_name: str, object_name: str) -> None:
+        bucket = self.client.bucket(bucket_name)
+        blob: storage.blob.Blob = bucket.blob(object_name)
+        blob.delete()

--- a/lexy/storage/s3.py
+++ b/lexy/storage/s3.py
@@ -1,0 +1,56 @@
+import logging
+
+import boto3
+
+from lexy.core.config import settings
+from lexy.storage.base import StorageClient
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+
+class S3Client(StorageClient):
+
+    def __init__(self, **kwargs):
+        logger.info("Creating S3 client")
+        client_kwargs = {}
+        if settings.AWS_ACCESS_KEY_ID and settings.AWS_SECRET_ACCESS_KEY:
+            client_kwargs["aws_access_key_id"] = settings.AWS_ACCESS_KEY_ID
+            client_kwargs["aws_secret_access_key"] = settings.AWS_SECRET_ACCESS_KEY.get_secret_value()
+        if settings.AWS_REGION:
+            client_kwargs["region_name"] = settings.AWS_REGION
+        client_kwargs.update(kwargs)
+        self.client = boto3.client('s3', **client_kwargs)
+
+    def list_buckets(self) -> list[str]:
+        response = self.client.list_buckets()
+        return [bucket['Name'] for bucket in response['Buckets']]
+
+    def upload_object(self, fileobj, bucket_name: str, object_name: str, rewind: bool = True) -> dict:
+        if isinstance(fileobj, str):
+            with open(fileobj, 'rb') as f:
+                fileobj = f
+        else:
+            if rewind:
+                fileobj.seek(0)
+        self.client.upload_fileobj(fileobj, bucket_name, object_name)
+        # FIXME: refactor
+        return {
+            "storage_service": "s3",
+            "s3_bucket": bucket_name,
+            "s3_key": object_name,
+            # "s3_url": f"https://{bucket_name}.s3.amazonaws.com/{object_name}",
+            # "s3_uri": f"s3://{bucket_name}/{object_name}",
+        }
+
+    def generate_presigned_url(self, bucket_name: str, object_name: str, expiration: int = 3600) -> str:
+        url = self.client.generate_presigned_url('get_object',
+                                                 Params={
+                                                     'Bucket': bucket_name,
+                                                     'Key': object_name
+                                                 },
+                                                 ExpiresIn=expiration)
+        return url
+
+    def delete_object(self, bucket_name: str, object_name: str) -> None:
+        self.client.delete_object(Bucket=bucket_name, Key=object_name)

--- a/lexy_tests/test_collection.py
+++ b/lexy_tests/test_collection.py
@@ -39,7 +39,7 @@ class TestCollection:
         assert "default" in collection_names
 
     @pytest.mark.asyncio
-    async def test_create_collection(self, async_session):
+    async def test_create_collection(self, async_session, settings):
         collection = Collection(collection_name="test_collection", description="Test Collection")
         async_session.add(collection)
         await async_session.commit()
@@ -47,6 +47,7 @@ class TestCollection:
         assert collection.collection_id is not None
         assert collection.collection_name == "test_collection"
         assert collection.description == "Test Collection"
+        assert collection.config == settings.COLLECTION_DEFAULT_CONFIG
         assert collection.created_at is not None
         assert collection.updated_at is not None
 
@@ -57,12 +58,16 @@ class TestCollection:
         assert len(collections) == 1
         assert collections[0].collection_name == "test_collection"
         assert collections[0].description == "Test Collection"
+        assert collections[0].config == settings.COLLECTION_DEFAULT_CONFIG
 
     @pytest.mark.asyncio
-    async def test_create_collection_with_model_validate(self, async_session):
+    async def test_create_collection_with_model_validate(self, async_session, settings):
         collection = CollectionCreate(
             collection_name="test_collection_validated", description="Test Collection Validated"
         )
+        assert collection.collection_name == "test_collection_validated"
+        assert collection.description == "Test Collection Validated"
+        assert collection.config == settings.COLLECTION_DEFAULT_CONFIG
 
         db_collection = Collection.model_validate(collection)
         async_session.add(db_collection)
@@ -71,6 +76,7 @@ class TestCollection:
         assert db_collection.collection_id is not None
         assert db_collection.collection_name == "test_collection_validated"
         assert db_collection.description == "Test Collection Validated"
+        assert db_collection.config == settings.COLLECTION_DEFAULT_CONFIG
         assert db_collection.created_at is not None
         assert db_collection.updated_at is not None
 
@@ -81,6 +87,7 @@ class TestCollection:
         assert len(collections) == 1
         assert collections[0].collection_name == "test_collection_validated"
         assert collections[0].description == "Test Collection Validated"
+        assert collections[0].config == settings.COLLECTION_DEFAULT_CONFIG
 
     @pytest.mark.asyncio
     async def test_collection_crud(self, async_session):

--- a/lexy_tests/test_storage.py
+++ b/lexy_tests/test_storage.py
@@ -1,0 +1,291 @@
+import datetime
+import os
+import time
+
+import boto3
+import pytest
+from botocore.client import Config
+from google.cloud import storage
+from google.oauth2 import service_account
+
+from lexy.storage import signed_url_is_expired
+from lexy.storage.client import construct_key_for_document, construct_key_for_thumbnail
+from lexy.storage.gcs import GCSClient
+from lexy.storage.s3 import S3Client
+from lexy.models.document import Document
+
+
+@pytest.fixture(scope='module')
+def s3():
+    return boto3.client('s3')
+
+
+@pytest.fixture(scope='module')
+def s3v4():
+    return boto3.client('s3', config=Config(signature_version='s3v4'))
+
+
+@pytest.fixture(scope='module')
+def gcs(settings):
+    credentials_file = settings.GOOGLE_APPLICATION_CREDENTIALS
+    credentials = service_account.Credentials.from_service_account_file(credentials_file)
+    return storage.Client(credentials=credentials)
+
+
+@pytest.fixture(scope='module')
+def lx_s3():
+    return S3Client()
+
+
+@pytest.fixture(scope='module')
+def lx_s3v4():
+    config = Config(signature_version='s3v4')
+    return S3Client(config=config)
+
+
+@pytest.fixture(scope='module')
+def lx_gcs(settings):
+    return GCSClient()
+
+
+@pytest.fixture(scope='module')
+def test_file_document():
+    return 'sample_data/documents/hotd.txt'
+
+
+@pytest.fixture(scope='module')
+def test_s3_object(s3, test_file_document, settings):
+
+    bucket_name = settings.S3_TEST_BUCKET
+    object_prefix = settings.COLLECTION_DEFAULT_CONFIG['storage_prefix']
+    object_name = os.path.join(object_prefix, 'hotd.txt')
+
+    assert bucket_name is not None, "S3_TEST_BUCKET must be set to run these tests."
+
+    # Upload the test document
+    s3.upload_file(test_file_document, bucket_name, object_name)
+    print(f"Created test_s3_object: 's3://{bucket_name}/{object_name}'")
+
+    yield bucket_name, object_name
+
+    # Clean up
+    s3.delete_object(Bucket=bucket_name, Key=object_name)
+    print(f"Deleted test_s3_object: 's3://{bucket_name}/{object_name}'")
+
+
+@pytest.fixture(scope='module')
+def test_gcs_object(gcs, test_file_document, settings):
+
+    bucket_name = settings.GCS_TEST_BUCKET
+    object_prefix = settings.COLLECTION_DEFAULT_CONFIG['storage_prefix']
+    object_name = os.path.join(object_prefix, 'hotd.txt')
+
+    assert bucket_name is not None, "GCS_TEST_BUCKET must be set to run these tests."
+
+    # Upload the test document
+    bucket = gcs.bucket(bucket_name)
+    blob: storage.blob.Blob = bucket.blob(object_name)
+    with open(test_file_document, 'rb') as file:
+        blob.upload_from_file(file)
+    print(f"Created test_gcs_object: 'gs://{bucket_name}/{object_name}'")
+
+    yield bucket_name, object_name
+
+    # Clean up
+    blob.delete()
+    print(f"Deleted test_gcs_object: 'gs://{bucket_name}/{object_name}'")
+
+
+# TODO: add async tests
+class TestStorageClient:
+    """Tests for third-party clients."""
+
+    def test_s3_client(self, s3):
+        assert s3 is not None
+        buckets = s3.list_buckets()
+        print(f"s3: {buckets = }")
+        assert len(buckets) > 0
+
+    def test_s3v4_client(self, s3v4):
+        assert s3v4 is not None
+        buckets = s3v4.list_buckets()
+        print(f"s3v4: {buckets = }")
+        assert len(buckets) > 0
+
+    def test_gcs_client(self, gcs):
+        assert gcs is not None
+        buckets = list(gcs.list_buckets())
+        print(f"gcs: {buckets = }")
+        assert len(buckets) > 0
+
+    def test_generate_signed_url_s3(self, s3, test_s3_object):
+        bucket_name, object_name = test_s3_object
+        expiration = 3
+
+        s3_signed_url = s3.generate_presigned_url('get_object',
+                                                  Params={'Bucket': bucket_name, 'Key': object_name},
+                                                  ExpiresIn=expiration)
+        assert s3_signed_url is not None
+        # s3 url can also include the region
+        assert s3_signed_url.startswith(f"https://{bucket_name}.s3.")
+        assert f".amazonaws.com/{object_name}" in s3_signed_url
+        assert signed_url_is_expired(s3_signed_url, svc='Amz') is False
+        time.sleep(expiration)
+        assert signed_url_is_expired(s3_signed_url, svc='Amz') is True
+
+    def test_generate_signed_url_s3v4(self, s3v4, test_s3_object):
+        bucket_name, object_name = test_s3_object
+        expiration = 3
+
+        s3v4_signed_url = s3v4.generate_presigned_url('get_object',
+                                                      Params={'Bucket': bucket_name, 'Key': object_name},
+                                                      ExpiresIn=expiration)
+        assert s3v4_signed_url is not None
+        # s3 url can also include the region
+        assert s3v4_signed_url.startswith(f"https://{bucket_name}.s3.")
+        assert f".amazonaws.com/{object_name}" in s3v4_signed_url
+        assert signed_url_is_expired(s3v4_signed_url, svc='Amz') is False
+        time.sleep(expiration)
+        assert signed_url_is_expired(s3v4_signed_url, svc='Amz') is True
+
+    def test_generate_signed_url_gcs(self, gcs, test_gcs_object):
+        bucket_name, object_name = test_gcs_object
+        expiration = 3
+
+        bucket = gcs.bucket(bucket_name)
+        blob: storage.blob.Blob = bucket.blob(object_name)
+        gcs_signed_url = blob.generate_signed_url(expiration=datetime.timedelta(seconds=expiration),
+                                                  version="v4")
+        assert gcs_signed_url is not None
+        assert gcs_signed_url.startswith(f"https://storage.googleapis.com/{bucket_name}/{object_name}")
+        assert signed_url_is_expired(gcs_signed_url, svc='Goog') is False
+        time.sleep(expiration)
+        assert signed_url_is_expired(gcs_signed_url, svc='Goog') is True
+
+
+# TODO: add async tests
+class TestLexyStorageClient:
+    """Tests for Lexy storage clients (i.e., `lexy.storage.client.StorageClient`)."""
+
+    def test_lx_s3_client(self, lx_s3):
+        assert lx_s3 is not None
+        buckets = lx_s3.list_buckets()
+        print(f"lx_s3: {buckets = }")
+        assert len(buckets) > 0
+
+    def test_lx_s3v4_client(self, lx_s3v4):
+        assert lx_s3v4 is not None
+        buckets = lx_s3v4.list_buckets()
+        print(f"lx_s3v4: {buckets = }")
+        assert len(buckets) > 0
+
+    def test_lx_gcs_client(self, lx_gcs):
+        assert lx_gcs is not None
+        buckets = lx_gcs.list_buckets()
+        print(f"lx_gcs: {buckets = }")
+        assert len(buckets) > 0
+
+    def test_generate_presigned_url_lx_s3(self, lx_s3, test_s3_object):
+        bucket_name, object_name = test_s3_object
+        expiration = 3
+
+        s3_signed_url = lx_s3.generate_presigned_url(bucket_name, object_name, expiration)
+        assert s3_signed_url is not None
+        # s3 url can also include the region
+        assert s3_signed_url.startswith(f"https://{bucket_name}.s3.")
+        assert f".amazonaws.com/{object_name}" in s3_signed_url
+        assert signed_url_is_expired(s3_signed_url, svc='Amz') is False
+        time.sleep(expiration)
+        assert signed_url_is_expired(s3_signed_url, svc='Amz') is True
+
+    def test_generate_presigned_url_lx_s3v4(self, lx_s3v4, test_s3_object):
+        bucket_name, object_name = test_s3_object
+        expiration = 3
+
+        s3v4_signed_url = lx_s3v4.generate_presigned_url(bucket_name, object_name, expiration)
+        assert s3v4_signed_url is not None
+        # s3 url can also include the region
+        assert s3v4_signed_url.startswith(f"https://{bucket_name}.s3.")
+        assert f".amazonaws.com/{object_name}" in s3v4_signed_url
+        assert signed_url_is_expired(s3v4_signed_url, svc='Amz') is False
+        time.sleep(expiration)
+        assert signed_url_is_expired(s3v4_signed_url, svc='Amz') is True
+
+    def test_generate_presigned_url_lx_gcs(self, lx_gcs, test_gcs_object):
+        bucket_name, object_name = test_gcs_object
+        expiration = 3
+
+        gcs_signed_url = lx_gcs.generate_presigned_url(bucket_name, object_name, expiration)
+        assert gcs_signed_url is not None
+        assert gcs_signed_url.startswith(f"https://storage.googleapis.com/{bucket_name}/{object_name}")
+        assert signed_url_is_expired(gcs_signed_url, svc='Goog') is False
+        time.sleep(expiration)
+        assert signed_url_is_expired(gcs_signed_url, svc='Goog') is True
+
+
+class TestConstructStorageKeys:
+    """Tests for constructed storage keys."""
+
+    @pytest.mark.asyncio
+    async def test_construct_key_for_document_with_document(self):
+        document = Document(collection_id="123", document_id="456")
+        key = await construct_key_for_document(document=document)
+        assert key == "collections/123/documents/456"
+
+    @pytest.mark.asyncio
+    async def test_construct_key_for_document_with_collection_and_document_id(self):
+        key = await construct_key_for_document(collection_id="123", document_id="456")
+        assert key == "collections/123/documents/456"
+
+    @pytest.mark.asyncio
+    async def test_construct_key_for_document_with_path_prefix(self):
+        document = Document(collection_id="123", document_id="456")
+        key = await construct_key_for_document(document=document, path_prefix="public")
+        assert key == "public/collections/123/documents/456"
+
+    @pytest.mark.asyncio
+    async def test_construct_key_for_document_with_filename(self):
+        document = Document(collection_id="123", document_id="456")
+        key = await construct_key_for_document(document=document, filename="document.jpg")
+        assert key == "collections/123/documents/456/document.jpg"
+
+    @pytest.mark.asyncio
+    async def test_construct_key_for_document_without_document_or_ids(self):
+        with pytest.raises(ValueError, match="Either a document object or collection_id and document_id must be "
+                                             "provided."):
+            await construct_key_for_document()
+
+    @pytest.mark.asyncio
+    async def test_construct_key_for_thumbnail_with_document(self):
+        document = Document(collection_id="123", document_id="456")
+        key = await construct_key_for_thumbnail((200, 200), document=document)
+        assert key == "collections/123/thumbnails/200x200/456"
+
+    @pytest.mark.asyncio
+    async def test_construct_key_for_thumbnail_with_collection_and_document_id(self):
+        key = await construct_key_for_thumbnail((200, 200), collection_id="123", document_id="456")
+        assert key == "collections/123/thumbnails/200x200/456"
+
+    @pytest.mark.asyncio
+    async def test_construct_key_for_thumbnail_with_path_prefix(self):
+        document = Document(collection_id="123", document_id="456")
+        key = await construct_key_for_thumbnail((200, 200), document=document, path_prefix="public")
+        assert key == "public/collections/123/thumbnails/200x200/456"
+
+    @pytest.mark.asyncio
+    async def test_construct_key_for_thumbnail_with_filename(self):
+        document = Document(collection_id="123", document_id="456")
+        key = await construct_key_for_thumbnail((200, 200), document=document, filename="thumbnail.jpg")
+        assert key == "collections/123/thumbnails/200x200/456/thumbnail.jpg"
+
+    @pytest.mark.asyncio
+    async def test_construct_key_for_thumbnail_without_dims(self):
+        document = Document(collection_id="123", document_id="456")
+        with pytest.raises(ValueError, match="Thumbnail dimensions must be provided."):
+            await construct_key_for_thumbnail(None, document=document)
+
+    @pytest.mark.asyncio
+    async def test_construct_key_for_thumbnail_without_document_or_ids(self):
+        with pytest.raises(ValueError, match="Either a document object or collection_id and document_id must be "
+                                             "provided."):
+            await construct_key_for_thumbnail((200, 200))

--- a/poetry.lock
+++ b/poetry.lock
@@ -307,6 +307,17 @@ urllib3 = {version = ">=1.25.4,<2.2.0 || >2.2.0,<3", markers = "python_version >
 crt = ["awscrt (==0.19.19)"]
 
 [[package]]
+name = "cachetools"
+version = "5.3.3"
+description = "Extensible memoizing collections and decorators"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "cachetools-5.3.3-py3-none-any.whl", hash = "sha256:0abad1021d3f8325b2fc1d2e9c8b9c9d57b04c3932657a72465447332c24d945"},
+    {file = "cachetools-5.3.3.tar.gz", hash = "sha256:ba29e2dfa0b8b556606f097407ed1aa62080ee108ab0dc5ec9d6a723a007d105"},
+]
+
+[[package]]
 name = "celery"
 version = "5.3.6"
 description = "Distributed Task Queue."
@@ -887,6 +898,207 @@ gitdb = ">=4.0.1,<5"
 
 [package.extras]
 test = ["black", "coverage[toml]", "ddt (>=1.1.1,!=1.4.3)", "mock", "mypy", "pre-commit", "pytest (>=7.3.1)", "pytest-cov", "pytest-instafail", "pytest-mock", "pytest-sugar"]
+
+[[package]]
+name = "google-api-core"
+version = "2.18.0"
+description = "Google API client core library"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "google-api-core-2.18.0.tar.gz", hash = "sha256:62d97417bfc674d6cef251e5c4d639a9655e00c45528c4364fbfebb478ce72a9"},
+    {file = "google_api_core-2.18.0-py3-none-any.whl", hash = "sha256:5a63aa102e0049abe85b5b88cb9409234c1f70afcda21ce1e40b285b9629c1d6"},
+]
+
+[package.dependencies]
+google-auth = ">=2.14.1,<3.0.dev0"
+googleapis-common-protos = ">=1.56.2,<2.0.dev0"
+proto-plus = ">=1.22.3,<2.0.0dev"
+protobuf = ">=3.19.5,<3.20.0 || >3.20.0,<3.20.1 || >3.20.1,<4.21.0 || >4.21.0,<4.21.1 || >4.21.1,<4.21.2 || >4.21.2,<4.21.3 || >4.21.3,<4.21.4 || >4.21.4,<4.21.5 || >4.21.5,<5.0.0.dev0"
+requests = ">=2.18.0,<3.0.0.dev0"
+
+[package.extras]
+grpc = ["grpcio (>=1.33.2,<2.0dev)", "grpcio (>=1.49.1,<2.0dev)", "grpcio-status (>=1.33.2,<2.0.dev0)", "grpcio-status (>=1.49.1,<2.0.dev0)"]
+grpcgcp = ["grpcio-gcp (>=0.2.2,<1.0.dev0)"]
+grpcio-gcp = ["grpcio-gcp (>=0.2.2,<1.0.dev0)"]
+
+[[package]]
+name = "google-auth"
+version = "2.29.0"
+description = "Google Authentication Library"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "google-auth-2.29.0.tar.gz", hash = "sha256:672dff332d073227550ffc7457868ac4218d6c500b155fe6cc17d2b13602c360"},
+    {file = "google_auth-2.29.0-py2.py3-none-any.whl", hash = "sha256:d452ad095688cd52bae0ad6fafe027f6a6d6f560e810fec20914e17a09526415"},
+]
+
+[package.dependencies]
+cachetools = ">=2.0.0,<6.0"
+pyasn1-modules = ">=0.2.1"
+rsa = ">=3.1.4,<5"
+
+[package.extras]
+aiohttp = ["aiohttp (>=3.6.2,<4.0.0.dev0)", "requests (>=2.20.0,<3.0.0.dev0)"]
+enterprise-cert = ["cryptography (==36.0.2)", "pyopenssl (==22.0.0)"]
+pyopenssl = ["cryptography (>=38.0.3)", "pyopenssl (>=20.0.0)"]
+reauth = ["pyu2f (>=0.1.5)"]
+requests = ["requests (>=2.20.0,<3.0.0.dev0)"]
+
+[[package]]
+name = "google-cloud-core"
+version = "2.4.1"
+description = "Google Cloud API client core library"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "google-cloud-core-2.4.1.tar.gz", hash = "sha256:9b7749272a812bde58fff28868d0c5e2f585b82f37e09a1f6ed2d4d10f134073"},
+    {file = "google_cloud_core-2.4.1-py2.py3-none-any.whl", hash = "sha256:a9e6a4422b9ac5c29f79a0ede9485473338e2ce78d91f2370c01e730eab22e61"},
+]
+
+[package.dependencies]
+google-api-core = ">=1.31.6,<2.0.dev0 || >2.3.0,<3.0.0dev"
+google-auth = ">=1.25.0,<3.0dev"
+
+[package.extras]
+grpc = ["grpcio (>=1.38.0,<2.0dev)", "grpcio-status (>=1.38.0,<2.0.dev0)"]
+
+[[package]]
+name = "google-cloud-storage"
+version = "2.16.0"
+description = "Google Cloud Storage API client library"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "google-cloud-storage-2.16.0.tar.gz", hash = "sha256:dda485fa503710a828d01246bd16ce9db0823dc51bbca742ce96a6817d58669f"},
+    {file = "google_cloud_storage-2.16.0-py2.py3-none-any.whl", hash = "sha256:91a06b96fb79cf9cdfb4e759f178ce11ea885c79938f89590344d079305f5852"},
+]
+
+[package.dependencies]
+google-api-core = ">=2.15.0,<3.0.0dev"
+google-auth = ">=2.26.1,<3.0dev"
+google-cloud-core = ">=2.3.0,<3.0dev"
+google-crc32c = ">=1.0,<2.0dev"
+google-resumable-media = ">=2.6.0"
+requests = ">=2.18.0,<3.0.0dev"
+
+[package.extras]
+protobuf = ["protobuf (<5.0.0dev)"]
+
+[[package]]
+name = "google-crc32c"
+version = "1.5.0"
+description = "A python wrapper of the C library 'Google CRC32C'"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "google-crc32c-1.5.0.tar.gz", hash = "sha256:89284716bc6a5a415d4eaa11b1726d2d60a0cd12aadf5439828353662ede9dd7"},
+    {file = "google_crc32c-1.5.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:596d1f98fc70232fcb6590c439f43b350cb762fb5d61ce7b0e9db4539654cc13"},
+    {file = "google_crc32c-1.5.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:be82c3c8cfb15b30f36768797a640e800513793d6ae1724aaaafe5bf86f8f346"},
+    {file = "google_crc32c-1.5.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:461665ff58895f508e2866824a47bdee72497b091c730071f2b7575d5762ab65"},
+    {file = "google_crc32c-1.5.0-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e2096eddb4e7c7bdae4bd69ad364e55e07b8316653234a56552d9c988bd2d61b"},
+    {file = "google_crc32c-1.5.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:116a7c3c616dd14a3de8c64a965828b197e5f2d121fedd2f8c5585c547e87b02"},
+    {file = "google_crc32c-1.5.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:5829b792bf5822fd0a6f6eb34c5f81dd074f01d570ed7f36aa101d6fc7a0a6e4"},
+    {file = "google_crc32c-1.5.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:64e52e2b3970bd891309c113b54cf0e4384762c934d5ae56e283f9a0afcd953e"},
+    {file = "google_crc32c-1.5.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:02ebb8bf46c13e36998aeaad1de9b48f4caf545e91d14041270d9dca767b780c"},
+    {file = "google_crc32c-1.5.0-cp310-cp310-win32.whl", hash = "sha256:2e920d506ec85eb4ba50cd4228c2bec05642894d4c73c59b3a2fe20346bd00ee"},
+    {file = "google_crc32c-1.5.0-cp310-cp310-win_amd64.whl", hash = "sha256:07eb3c611ce363c51a933bf6bd7f8e3878a51d124acfc89452a75120bc436289"},
+    {file = "google_crc32c-1.5.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:cae0274952c079886567f3f4f685bcaf5708f0a23a5f5216fdab71f81a6c0273"},
+    {file = "google_crc32c-1.5.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1034d91442ead5a95b5aaef90dbfaca8633b0247d1e41621d1e9f9db88c36298"},
+    {file = "google_crc32c-1.5.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7c42c70cd1d362284289c6273adda4c6af8039a8ae12dc451dcd61cdabb8ab57"},
+    {file = "google_crc32c-1.5.0-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8485b340a6a9e76c62a7dce3c98e5f102c9219f4cfbf896a00cf48caf078d438"},
+    {file = "google_crc32c-1.5.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:77e2fd3057c9d78e225fa0a2160f96b64a824de17840351b26825b0848022906"},
+    {file = "google_crc32c-1.5.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:f583edb943cf2e09c60441b910d6a20b4d9d626c75a36c8fcac01a6c96c01183"},
+    {file = "google_crc32c-1.5.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:a1fd716e7a01f8e717490fbe2e431d2905ab8aa598b9b12f8d10abebb36b04dd"},
+    {file = "google_crc32c-1.5.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:72218785ce41b9cfd2fc1d6a017dc1ff7acfc4c17d01053265c41a2c0cc39b8c"},
+    {file = "google_crc32c-1.5.0-cp311-cp311-win32.whl", hash = "sha256:66741ef4ee08ea0b2cc3c86916ab66b6aef03768525627fd6a1b34968b4e3709"},
+    {file = "google_crc32c-1.5.0-cp311-cp311-win_amd64.whl", hash = "sha256:ba1eb1843304b1e5537e1fca632fa894d6f6deca8d6389636ee5b4797affb968"},
+    {file = "google_crc32c-1.5.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:98cb4d057f285bd80d8778ebc4fde6b4d509ac3f331758fb1528b733215443ae"},
+    {file = "google_crc32c-1.5.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fd8536e902db7e365f49e7d9029283403974ccf29b13fc7028b97e2295b33556"},
+    {file = "google_crc32c-1.5.0-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:19e0a019d2c4dcc5e598cd4a4bc7b008546b0358bd322537c74ad47a5386884f"},
+    {file = "google_crc32c-1.5.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:02c65b9817512edc6a4ae7c7e987fea799d2e0ee40c53ec573a692bee24de876"},
+    {file = "google_crc32c-1.5.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:6ac08d24c1f16bd2bf5eca8eaf8304812f44af5cfe5062006ec676e7e1d50afc"},
+    {file = "google_crc32c-1.5.0-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:3359fc442a743e870f4588fcf5dcbc1bf929df1fad8fb9905cd94e5edb02e84c"},
+    {file = "google_crc32c-1.5.0-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:1e986b206dae4476f41bcec1faa057851f3889503a70e1bdb2378d406223994a"},
+    {file = "google_crc32c-1.5.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:de06adc872bcd8c2a4e0dc51250e9e65ef2ca91be023b9d13ebd67c2ba552e1e"},
+    {file = "google_crc32c-1.5.0-cp37-cp37m-win32.whl", hash = "sha256:d3515f198eaa2f0ed49f8819d5732d70698c3fa37384146079b3799b97667a94"},
+    {file = "google_crc32c-1.5.0-cp37-cp37m-win_amd64.whl", hash = "sha256:67b741654b851abafb7bc625b6d1cdd520a379074e64b6a128e3b688c3c04740"},
+    {file = "google_crc32c-1.5.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:c02ec1c5856179f171e032a31d6f8bf84e5a75c45c33b2e20a3de353b266ebd8"},
+    {file = "google_crc32c-1.5.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:edfedb64740750e1a3b16152620220f51d58ff1b4abceb339ca92e934775c27a"},
+    {file = "google_crc32c-1.5.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:84e6e8cd997930fc66d5bb4fde61e2b62ba19d62b7abd7a69920406f9ecca946"},
+    {file = "google_crc32c-1.5.0-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:024894d9d3cfbc5943f8f230e23950cd4906b2fe004c72e29b209420a1e6b05a"},
+    {file = "google_crc32c-1.5.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:998679bf62b7fb599d2878aa3ed06b9ce688b8974893e7223c60db155f26bd8d"},
+    {file = "google_crc32c-1.5.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:83c681c526a3439b5cf94f7420471705bbf96262f49a6fe546a6db5f687a3d4a"},
+    {file = "google_crc32c-1.5.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:4c6fdd4fccbec90cc8a01fc00773fcd5fa28db683c116ee3cb35cd5da9ef6c37"},
+    {file = "google_crc32c-1.5.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:5ae44e10a8e3407dbe138984f21e536583f2bba1be9491239f942c2464ac0894"},
+    {file = "google_crc32c-1.5.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:37933ec6e693e51a5b07505bd05de57eee12f3e8c32b07da7e73669398e6630a"},
+    {file = "google_crc32c-1.5.0-cp38-cp38-win32.whl", hash = "sha256:fe70e325aa68fa4b5edf7d1a4b6f691eb04bbccac0ace68e34820d283b5f80d4"},
+    {file = "google_crc32c-1.5.0-cp38-cp38-win_amd64.whl", hash = "sha256:74dea7751d98034887dbd821b7aae3e1d36eda111d6ca36c206c44478035709c"},
+    {file = "google_crc32c-1.5.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:c6c777a480337ac14f38564ac88ae82d4cd238bf293f0a22295b66eb89ffced7"},
+    {file = "google_crc32c-1.5.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:759ce4851a4bb15ecabae28f4d2e18983c244eddd767f560165563bf9aefbc8d"},
+    {file = "google_crc32c-1.5.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f13cae8cc389a440def0c8c52057f37359014ccbc9dc1f0827936bcd367c6100"},
+    {file = "google_crc32c-1.5.0-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e560628513ed34759456a416bf86b54b2476c59144a9138165c9a1575801d0d9"},
+    {file = "google_crc32c-1.5.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e1674e4307fa3024fc897ca774e9c7562c957af85df55efe2988ed9056dc4e57"},
+    {file = "google_crc32c-1.5.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:278d2ed7c16cfc075c91378c4f47924c0625f5fc84b2d50d921b18b7975bd210"},
+    {file = "google_crc32c-1.5.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:d5280312b9af0976231f9e317c20e4a61cd2f9629b7bfea6a693d1878a264ebd"},
+    {file = "google_crc32c-1.5.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:8b87e1a59c38f275c0e3676fc2ab6d59eccecfd460be267ac360cc31f7bcde96"},
+    {file = "google_crc32c-1.5.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:7c074fece789b5034b9b1404a1f8208fc2d4c6ce9decdd16e8220c5a793e6f61"},
+    {file = "google_crc32c-1.5.0-cp39-cp39-win32.whl", hash = "sha256:7f57f14606cd1dd0f0de396e1e53824c371e9544a822648cd76c034d209b559c"},
+    {file = "google_crc32c-1.5.0-cp39-cp39-win_amd64.whl", hash = "sha256:a2355cba1f4ad8b6988a4ca3feed5bff33f6af2d7f134852cf279c2aebfde541"},
+    {file = "google_crc32c-1.5.0-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:f314013e7dcd5cf45ab1945d92e713eec788166262ae8deb2cfacd53def27325"},
+    {file = "google_crc32c-1.5.0-pp37-pypy37_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3b747a674c20a67343cb61d43fdd9207ce5da6a99f629c6e2541aa0e89215bcd"},
+    {file = "google_crc32c-1.5.0-pp37-pypy37_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8f24ed114432de109aa9fd317278518a5af2d31ac2ea6b952b2f7782b43da091"},
+    {file = "google_crc32c-1.5.0-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b8667b48e7a7ef66afba2c81e1094ef526388d35b873966d8a9a447974ed9178"},
+    {file = "google_crc32c-1.5.0-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:1c7abdac90433b09bad6c43a43af253e688c9cfc1c86d332aed13f9a7c7f65e2"},
+    {file = "google_crc32c-1.5.0-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:6f998db4e71b645350b9ac28a2167e6632c239963ca9da411523bb439c5c514d"},
+    {file = "google_crc32c-1.5.0-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9c99616c853bb585301df6de07ca2cadad344fd1ada6d62bb30aec05219c45d2"},
+    {file = "google_crc32c-1.5.0-pp38-pypy38_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2ad40e31093a4af319dadf503b2467ccdc8f67c72e4bcba97f8c10cb078207b5"},
+    {file = "google_crc32c-1.5.0-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cd67cf24a553339d5062eff51013780a00d6f97a39ca062781d06b3a73b15462"},
+    {file = "google_crc32c-1.5.0-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:398af5e3ba9cf768787eef45c803ff9614cc3e22a5b2f7d7ae116df8b11e3314"},
+    {file = "google_crc32c-1.5.0-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:b1f8133c9a275df5613a451e73f36c2aea4fe13c5c8997e22cf355ebd7bd0728"},
+    {file = "google_crc32c-1.5.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9ba053c5f50430a3fcfd36f75aff9caeba0440b2d076afdb79a318d6ca245f88"},
+    {file = "google_crc32c-1.5.0-pp39-pypy39_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:272d3892a1e1a2dbc39cc5cde96834c236d5327e2122d3aaa19f6614531bb6eb"},
+    {file = "google_crc32c-1.5.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:635f5d4dd18758a1fbd1049a8e8d2fee4ffed124462d837d1a02a0e009c3ab31"},
+    {file = "google_crc32c-1.5.0-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:c672d99a345849301784604bfeaeba4db0c7aae50b95be04dd651fd2a7310b93"},
+]
+
+[package.extras]
+testing = ["pytest"]
+
+[[package]]
+name = "google-resumable-media"
+version = "2.7.0"
+description = "Utilities for Google Media Downloads and Resumable Uploads"
+optional = false
+python-versions = ">= 3.7"
+files = [
+    {file = "google-resumable-media-2.7.0.tar.gz", hash = "sha256:5f18f5fa9836f4b083162064a1c2c98c17239bfda9ca50ad970ccf905f3e625b"},
+    {file = "google_resumable_media-2.7.0-py2.py3-none-any.whl", hash = "sha256:79543cfe433b63fd81c0844b7803aba1bb8950b47bedf7d980c38fa123937e08"},
+]
+
+[package.dependencies]
+google-crc32c = ">=1.0,<2.0dev"
+
+[package.extras]
+aiohttp = ["aiohttp (>=3.6.2,<4.0.0dev)", "google-auth (>=1.22.0,<2.0dev)"]
+requests = ["requests (>=2.18.0,<3.0.0dev)"]
+
+[[package]]
+name = "googleapis-common-protos"
+version = "1.63.0"
+description = "Common protobufs used in Google APIs"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "googleapis-common-protos-1.63.0.tar.gz", hash = "sha256:17ad01b11d5f1d0171c06d3ba5c04c54474e883b66b949722b4938ee2694ef4e"},
+    {file = "googleapis_common_protos-1.63.0-py2.py3-none-any.whl", hash = "sha256:ae45f75702f7c08b541f750854a678bd8f534a1a6bace6afe975f1d0a82d6632"},
+]
+
+[package.dependencies]
+protobuf = ">=3.19.5,<3.20.0 || >3.20.0,<3.20.1 || >3.20.1,<4.21.1 || >4.21.1,<4.21.2 || >4.21.2,<4.21.3 || >4.21.3,<4.21.4 || >4.21.4,<4.21.5 || >4.21.5,<5.0.0.dev0"
+
+[package.extras]
+grpc = ["grpcio (>=1.44.0,<2.0.0.dev0)"]
 
 [[package]]
 name = "greenlet"
@@ -1896,6 +2108,43 @@ files = [
 wcwidth = "*"
 
 [[package]]
+name = "proto-plus"
+version = "1.23.0"
+description = "Beautiful, Pythonic protocol buffers."
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "proto-plus-1.23.0.tar.gz", hash = "sha256:89075171ef11988b3fa157f5dbd8b9cf09d65fffee97e29ce403cd8defba19d2"},
+    {file = "proto_plus-1.23.0-py3-none-any.whl", hash = "sha256:a829c79e619e1cf632de091013a4173deed13a55f326ef84f05af6f50ff4c82c"},
+]
+
+[package.dependencies]
+protobuf = ">=3.19.0,<5.0.0dev"
+
+[package.extras]
+testing = ["google-api-core[grpc] (>=1.31.5)"]
+
+[[package]]
+name = "protobuf"
+version = "4.25.3"
+description = ""
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "protobuf-4.25.3-cp310-abi3-win32.whl", hash = "sha256:d4198877797a83cbfe9bffa3803602bbe1625dc30d8a097365dbc762e5790faa"},
+    {file = "protobuf-4.25.3-cp310-abi3-win_amd64.whl", hash = "sha256:209ba4cc916bab46f64e56b85b090607a676f66b473e6b762e6f1d9d591eb2e8"},
+    {file = "protobuf-4.25.3-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:f1279ab38ecbfae7e456a108c5c0681e4956d5b1090027c1de0f934dfdb4b35c"},
+    {file = "protobuf-4.25.3-cp37-abi3-manylinux2014_aarch64.whl", hash = "sha256:e7cb0ae90dd83727f0c0718634ed56837bfeeee29a5f82a7514c03ee1364c019"},
+    {file = "protobuf-4.25.3-cp37-abi3-manylinux2014_x86_64.whl", hash = "sha256:7c8daa26095f82482307bc717364e7c13f4f1c99659be82890dcfc215194554d"},
+    {file = "protobuf-4.25.3-cp38-cp38-win32.whl", hash = "sha256:f4f118245c4a087776e0a8408be33cf09f6c547442c00395fbfb116fac2f8ac2"},
+    {file = "protobuf-4.25.3-cp38-cp38-win_amd64.whl", hash = "sha256:c053062984e61144385022e53678fbded7aea14ebb3e0305ae3592fb219ccfa4"},
+    {file = "protobuf-4.25.3-cp39-cp39-win32.whl", hash = "sha256:19b270aeaa0099f16d3ca02628546b8baefe2955bbe23224aaf856134eccf1e4"},
+    {file = "protobuf-4.25.3-cp39-cp39-win_amd64.whl", hash = "sha256:e3c97a1555fd6388f857770ff8b9703083de6bf1f9274a002a332d65fbb56c8c"},
+    {file = "protobuf-4.25.3-py3-none-any.whl", hash = "sha256:f0700d54bcf45424477e46a9f0944155b46fb0639d69728739c0e47bab83f2b9"},
+    {file = "protobuf-4.25.3.tar.gz", hash = "sha256:25b5d0b42fd000320bd7830b349e3b696435f3b329810427a6bcce6a5492cc5c"},
+]
+
+[[package]]
 name = "psutil"
 version = "5.9.8"
 description = "Cross-platform lib for process and system monitoring in Python."
@@ -2014,6 +2263,20 @@ files = [
     {file = "pyasn1-0.6.0-py2.py3-none-any.whl", hash = "sha256:cca4bb0f2df5504f02f6f8a775b6e416ff9b0b3b16f7ee80b5a3153d9b804473"},
     {file = "pyasn1-0.6.0.tar.gz", hash = "sha256:3a35ab2c4b5ef98e17dfdec8ab074046fbda76e281c5a706ccd82328cfc8f64c"},
 ]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.0"
+description = "A collection of ASN.1-based protocols modules"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pyasn1_modules-0.4.0-py3-none-any.whl", hash = "sha256:be04f15b66c206eed667e0bb5ab27e2b1855ea54a842e5037738099e8ca4ae0b"},
+    {file = "pyasn1_modules-0.4.0.tar.gz", hash = "sha256:831dbcea1b177b28c9baddf4c6d1013c24c3accd14a1873fffaa6a2e905f17b6"},
+]
+
+[package.dependencies]
+pyasn1 = ">=0.4.6,<0.7.0"
 
 [[package]]
 name = "pycparser"
@@ -3520,4 +3783,4 @@ lexy-transformers = ["openai", "sentence-transformers", "transformers"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "d529ecfb6ac31c4d36e0a162341e63b64f18ac4d91159f87e953882ba2e664dc"
+content-hash = "cff1b26e8deca08dad458e103d023554d703450feb50f2eb87e162ff2e9981eb"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ python-multipart = "^0.0.6"
 httpx = "^0.24.1"
 awscli = "^1.32.4"
 boto3 = "^1.34.4"
+google-cloud-storage = "^2.16.0"
 Pillow = "^10.0.1"
 pgvector = "^0.2.5"
 
@@ -78,6 +79,7 @@ pymdown-extensions = "^10.3"
 asyncio_mode = "auto"
 env = [
     "RUN_ENV=test",
+    "LEXY_CONFIG=testing",
     "CELERY_CONFIG=testing",
 ]
 

--- a/sdk-python/lexy_py/document/models.py
+++ b/sdk-python/lexy_py/document/models.py
@@ -76,7 +76,8 @@ class Document(DocumentModel):
             self._refresh_urls()
         url = self._urls.get('object', None)
         # check if url is expired and refresh if needed
-        if url and presigned_url_is_expired(url):
+        storage_service = self.meta.get('storage_service')
+        if url and presigned_url_is_expired(url, storage_service=storage_service):
             self._refresh_urls()
             url = self._urls.get('object', None)
         return url
@@ -89,7 +90,9 @@ class Document(DocumentModel):
         if not url:
             url = next(iter(self._urls.get('thumbnails', {}).values()), None)
         # check if url is expired and refresh if needed
-        if url and presigned_url_is_expired(url):
+        storage_service = (self.meta.get('image', {}).get('thumbnails', {}).get(f'{size[0]}x{size[1]}', {})
+                           .get('storage_service'))
+        if url and presigned_url_is_expired(url, storage_service=storage_service):
             return self.get_thumbnail_url(size, refresh=True)
         return url
     thumbnail_url = property(get_thumbnail_url)

--- a/sdk-python/lexy_py/storage.py
+++ b/sdk-python/lexy_py/storage.py
@@ -1,31 +1,45 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
+from typing import Literal
 from urllib.parse import parse_qs, urlparse
 
 
-def presigned_url_is_expired(url, storage_service: str = 's3') -> bool:
+def presigned_url_is_expired(url: str, storage_service: str = 's3') -> bool:
     if storage_service == 's3':
-        return s3_presigned_url_is_expired(url)
-    elif storage_service == 'azure':
-        raise NotImplementedError
+        return signed_url_is_expired(url, svc='Amz')
     elif storage_service == 'gcs':
+        return signed_url_is_expired(url, svc='Goog')
+    elif storage_service == 'azure':
         raise NotImplementedError
     else:
         raise ValueError(f'Unsupported storage service: {storage_service} - '
-                         f'must be one of the following: s3, azure, gcs')
+                         f'must be one of the following: s3, gcs, azure')
 
 
-def s3_presigned_url_is_expired(url) -> bool:
-    query = parse_qs(urlparse(url).query)
-    if 'X-Amz-Expires' in query:
-        expiration = query['X-Amz-Expires'][0]
-        expiration = int(expiration)
-        expiration = timedelta(seconds=expiration)
-        expiration = datetime.now() + expiration
-        return expiration < datetime.now()
-    elif 'Expires' in query:
-        expiration = query['Expires'][0]
-        expiration = int(expiration)
-        expiration = datetime.fromtimestamp(expiration)
-        return expiration < datetime.now()
+def signed_url_is_expired(url: str, svc: Literal['Amz', 'Goog']):
+    """Checks if a signed URL (V2 or V4) has expired.
+
+    Args:
+        url (str): The signed URL string.
+        svc (Literal['Amz', 'Goog']): The service query parameter used to check for expiration in V4 signatures.
+            Either 'Amz' for AWS or 'Goog' for GCP.
+
+    Returns:
+        True if the signed URL is expired, False otherwise.
+
+    Raises:
+        ValueError: If no expiration found in signed url.
+    """
+    query_params = parse_qs(urlparse(url).query)
+    # V4 signature
+    if f'X-{svc}-Expires' in query_params:
+        expires_in = int(query_params[f'X-{svc}-Expires'][0])
+        issued_at_dt = datetime.fromisoformat(query_params[f'X-{svc}-Date'][0])
+        expires_at_dt = issued_at_dt + timedelta(seconds=expires_in)
+        return expires_at_dt < datetime.now(tz=timezone.utc)
+    # V2 signature
+    elif 'Expires' in query_params:
+        expires_at = int(query_params['Expires'][0])
+        expires_at_dt = datetime.fromtimestamp(expires_at, tz=timezone.utc)
+        return expires_at_dt < datetime.now(tz=timezone.utc)
     else:
-        raise ValueError('No expiration found in presigned url')
+        raise ValueError('No expiration found in signed url')

--- a/sdk-python/lexy_py_tests/conftest.py
+++ b/sdk-python/lexy_py_tests/conftest.py
@@ -12,25 +12,26 @@ from lexy_tests.conftest import (
     celery_config,
     client,
     create_test_database,
-    create_test_engine,
     get_session,
     seed_data,
     settings,
     sync_engine,
     test_app,
-    test_engine,
     test_settings,
     use_celery_app_trap,
 )
 from lexy_py import LexyClient
 
 
-DB_WARNING_MSG = "There's a good chance you're about to drop the wrong database! Double check your test settings."
-assert test_settings.POSTGRES_DB != "lexy", DB_WARNING_MSG
-test_settings.DB_ECHO_LOG = False
-
-# the value of CELERY_CONFIG is set using pytest-env plugin in pyproject.toml
+# the value of LEXY_CONFIG and CELERY_CONFIG are set using pytest-env plugin in pyproject.toml
+assert os.environ.get("LEXY_CONFIG") == "testing", "LEXY_CONFIG is not set to 'testing'"
 assert os.environ.get("CELERY_CONFIG") == "testing", "CELERY_CONFIG is not set to 'testing'"
+
+
+DB_WARNING_MSG = ("There's a good chance you're about to drop the wrong database! "
+                  "Double check your test settings.")
+assert test_settings.POSTGRES_DB != "lexy", DB_WARNING_MSG
+
 
 TEST_BASE_URL = "http://test"
 TEST_API_TIMEOUT = 10


### PR DESCRIPTION
# What

- Created `StorageClient` as abstract base class to include both S3 and GCS
- Updated endpoints to use new dependency `get_storage_client`
- Updated logic for expiration of signed object urls
- Created new settings for `DEFAULT_STORAGE_SERVICE` and `DEFAULT_STORAGE_BUCKET`
- Broke AppSettings into production and development configs
  + Simplified overrides in `lexy_tests.conftest.py`
- Fixed pipeline_dir mounting issue with Docker
- Added `google-cloud-storage` as a dependency
- Added tests

NOTE: Currently, only one of S3 or GCS can be configured as the storage backend. Still need to allow storage by Collection, which requires removing the `get_storage_client` dependency and fetching the storage client based on the collection.
  
# Why

Generalizes storage backend to include services other than S3.

# Test plan

- [x] Run `make run-tests` and verify that all tests pass
- [x] Run `examples/tests.ipynb` and verify that there are no errors
- [x] Run `examples/images.ipynb` and verify that the tutorial works as expected