### PR TITLE
Make target for dropping db tables in postgres container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,3 +72,13 @@ update-doc-reqs: check-env
 run-tests: check-env
 	pytest lexy_tests
 	pytest sdk-python
+
+drop-db-tables:
+	# stop the server
+	docker-compose stop lexyserver lexyworker
+	# copy the drop_tables function to the postgres container
+	docker cp scripts/drop_tables.sql lexy-postgres:/tmp/drop_tables.sql
+	# execute the script to drop all tables in public schema
+	docker exec lexy-postgres psql -U postgres -d lexy -f /tmp/drop_tables.sql
+	# restart the server
+	docker-compose start lexyserver lexyworker

--- a/scripts/drop_tables.sql
+++ b/scripts/drop_tables.sql
@@ -1,0 +1,11 @@
+DO
+$$
+    DECLARE
+        r RECORD;
+    BEGIN
+        FOR r IN (SELECT tablename FROM pg_tables WHERE schemaname = 'public')
+            LOOP
+                EXECUTE 'DROP TABLE IF EXISTS public.' || quote_ident(r.tablename) || ' CASCADE';
+            END LOOP;
+    END
+$$;


### PR DESCRIPTION
# What

Use `make drop-db-tables` to drop tables in postgres container.

# Why

Easier to reset the db during development.

# Test plan

- [x] Run `make run-tests` and verify that all tests pass
- [ ] Run `examples/tests.ipynb` and verify that there are no errors
- [ ] Run `examples/images.ipynb` and verify that the tutorial works as expected
