### PR TITLE
Bugfix for test celery worker

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,9 +2,6 @@ name: Build and Push Docker Images
 
 on:
   push:
-    branches:
-#      - main
-      - rs/bugfix-test-celery-worker
     tags:
       - v*
 

--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -168,6 +168,7 @@ Available packages are [here](https://github.com/orgs/lexy-ai/packages?repo_name
             environment:
               - OPENAI_API_KEY=${OPENAI_API_KEY}
               - PIPELINE_DIR=/home/app/pipelines
+              - GOOGLE_APPLICATION_CREDENTIALS=/run/secrets/gcp_credentials
             volumes:
               - ${PIPELINE_DIR:-./pipelines}:/home/app/pipelines
             secrets:


### PR DESCRIPTION
# What

Changed celery test settings to not import pipelines directory. This fixes a bug where tests requiring the celery worker fixture would fail if there were any pipeline extras not installed in lexy-server.

# Test plan

- [x] Run `make run-tests` and verify that all tests pass
- [ ] Run `examples/tests.ipynb` and verify that there are no errors
- [ ] Run `examples/images.ipynb` and verify that the tutorial works as expected
