### PR TITLE
Refactor s3_bucket and s3_key

### DIFF
--- a/lexy/models/document.py
+++ b/lexy/models/document.py
@@ -34,7 +34,9 @@ class DocumentBase(SQLModel):
 
     @property
     def is_stored_object(self) -> bool:
-        return bool(self.meta.get('storage_service') and self.meta.get('s3_bucket') and self.meta.get('s3_key'))
+        return bool(
+            self.meta.get('storage_service') and self.meta.get('storage_bucket') and self.meta.get('storage_key')
+        )
 
     @property
     def image(self) -> Image:

--- a/lexy/storage/client.py
+++ b/lexy/storage/client.py
@@ -61,10 +61,10 @@ def generate_signed_urls_for_document(document: Union["Document", "DocumentBase"
     presigned_urls = {}
 
     # url for the document object
-    if document.meta.get('s3_bucket') and document.meta.get('s3_key'):
+    if document.meta.get('storage_bucket') and document.meta.get('storage_key'):
         presigned_urls["object"] = (
-            storage_client.generate_presigned_url(bucket_name=document.meta.get('s3_bucket'),
-                                                  object_name=document.meta.get('s3_key'),
+            storage_client.generate_presigned_url(bucket_name=document.meta.get('storage_bucket'),
+                                                  object_name=document.meta.get('storage_key'),
                                                   expiration=expiration)
         )
 
@@ -73,8 +73,8 @@ def generate_signed_urls_for_document(document: Union["Document", "DocumentBase"
         presigned_urls["thumbnails"] = {}
         for dims, vals in document.meta.get('image').get('thumbnails').items():
             presigned_urls["thumbnails"][dims] = (
-                storage_client.generate_presigned_url(bucket_name=vals.get('s3_bucket'),
-                                                      object_name=vals.get('s3_key'),
+                storage_client.generate_presigned_url(bucket_name=vals.get('storage_bucket'),
+                                                      object_name=vals.get('storage_key'),
                                                       expiration=expiration)
             )
 

--- a/lexy/storage/gcs.py
+++ b/lexy/storage/gcs.py
@@ -49,13 +49,12 @@ class GCSClient(StorageClient):
             blob.upload_from_filename(fileobj)
         else:
             blob.upload_from_file(fileobj, rewind=rewind)
-        # FIXME: refactor
         return {
             "storage_service": "gcs",
-            "s3_bucket": bucket_name,
-            "s3_key": object_name,
-            # "s3_url": f"https://storage.googleapis.com/{bucket_name}/{object_name}",
-            # "s3_uri": f"gs://{bucket_name}/{object_name}",
+            "storage_bucket": bucket_name,
+            "storage_key": object_name,
+            # "storage_url": f"https://storage.googleapis.com/{bucket_name}/{object_name}",
+            # "storage_uri": f"gs://{bucket_name}/{object_name}",
         }
 
     def generate_presigned_url(self, bucket_name: str, object_name: str, expiration: int = 3600) -> str:

--- a/lexy/storage/s3.py
+++ b/lexy/storage/s3.py
@@ -38,13 +38,12 @@ class S3Client(StorageClient):
             if rewind:
                 fileobj.seek(0)
         self.client.upload_fileobj(fileobj, bucket_name, object_name)
-        # FIXME: refactor
         return {
             "storage_service": "s3",
-            "s3_bucket": bucket_name,
-            "s3_key": object_name,
-            # "s3_url": f"https://{bucket_name}.s3.amazonaws.com/{object_name}",
-            # "s3_uri": f"s3://{bucket_name}/{object_name}",
+            "storage_bucket": bucket_name,
+            "storage_key": object_name,
+            # "storage_url": f"https://{bucket_name}.s3.amazonaws.com/{object_name}",
+            # "storage_uri": f"s3://{bucket_name}/{object_name}",
         }
 
     def generate_presigned_url(self, bucket_name: str, object_name: str, expiration: int = 3600) -> str:

--- a/sdk-python/lexy_py_tests/test_document.py
+++ b/sdk-python/lexy_py_tests/test_document.py
@@ -268,8 +268,8 @@ class TestDocumentClient:
         img = Image.open(BytesIO(r3.content))
         assert isinstance(img, Image.Image)
         assert img_doc.meta['filename'] == 'lexy-dalle.jpeg'
-        assert img_doc.meta['s3_bucket'] == storage_bucket
-        assert img_doc.meta['s3_key'] == f"lexy_tests/collections/{tmp_collection_id}/documents/lexy-dalle.jpeg"
+        assert img_doc.meta['storage_bucket'] == storage_bucket
+        assert img_doc.meta['storage_key'] == f"lexy_tests/collections/{tmp_collection_id}/documents/lexy-dalle.jpeg"
         assert img_doc.meta['size'] == 113352
         assert img_doc.meta['type'] == 'image'
         assert img_doc.meta['content_type'] == 'image/jpeg'
@@ -279,8 +279,8 @@ class TestDocumentClient:
         thumbnail_dims = list(settings.IMAGE_THUMBNAIL_SIZES)[0]
         thumbnail_dims_str = f"{thumbnail_dims[0]}x{thumbnail_dims[1]}"
         assert thumbnail_dims_str in img_doc.meta['image']['thumbnails']
-        assert img_doc.meta['image']['thumbnails'][thumbnail_dims_str]['s3_bucket'] == storage_bucket
-        assert img_doc.meta['image']['thumbnails'][thumbnail_dims_str]['s3_key'] == (
+        assert img_doc.meta['image']['thumbnails'][thumbnail_dims_str]['storage_bucket'] == storage_bucket
+        assert img_doc.meta['image']['thumbnails'][thumbnail_dims_str]['storage_key'] == (
             f"lexy_tests/collections/{tmp_collection_id}/thumbnails/{thumbnail_dims_str}/lexy-dalle.jpeg"
         )
 
@@ -322,8 +322,8 @@ class TestDocumentClient:
         # FIXME: lx_client.get() returns a 404 but httpx.get() returns a 200
         # assert pdf_doc.image is None
         assert pdf_doc.meta['filename'] == 'StarCoder.pdf'
-        assert pdf_doc.meta['s3_bucket'] == storage_bucket
-        assert pdf_doc.meta['s3_key'] == f"lexy_tests/collections/{tmp_collection_id}/documents/StarCoder.pdf"
+        assert pdf_doc.meta['storage_bucket'] == storage_bucket
+        assert pdf_doc.meta['storage_key'] == f"lexy_tests/collections/{tmp_collection_id}/documents/StarCoder.pdf"
         assert pdf_doc.meta['size'] == 629980
         assert pdf_doc.meta['type'] == 'pdf'
         assert pdf_doc.meta['content_type'] == 'application/pdf'
@@ -338,8 +338,8 @@ class TestDocumentClient:
         # FIXME: lx_client.get() returns a 404 but httpx.get() returns a 200
         # assert video_doc.image is None
         assert video_doc.meta['filename'] == 'fluid.mp4'
-        assert video_doc.meta['s3_bucket'] == storage_bucket
-        assert video_doc.meta['s3_key'] == f"lexy_tests/collections/{tmp_collection_id}/documents/fluid.mp4"
+        assert video_doc.meta['storage_bucket'] == storage_bucket
+        assert video_doc.meta['storage_key'] == f"lexy_tests/collections/{tmp_collection_id}/documents/fluid.mp4"
         assert video_doc.meta['size'] == 323778
         assert video_doc.meta['type'] == 'video'
         assert video_doc.meta['content_type'] == 'video/mp4'
@@ -356,8 +356,8 @@ class TestDocumentClient:
         # FIXME: lx_client.get() returns a 404 but httpx.get() returns a 200
         # assert text_doc.image is None
         assert text_doc.meta['filename'] == 'hotd.txt'
-        assert text_doc.meta['s3_bucket'] == storage_bucket
-        assert text_doc.meta['s3_key'] == f"lexy_tests/collections/{tmp_collection_id}/documents/hotd.txt"
+        assert text_doc.meta['storage_bucket'] == storage_bucket
+        assert text_doc.meta['storage_key'] == f"lexy_tests/collections/{tmp_collection_id}/documents/hotd.txt"
         assert text_doc.meta['size'] == 3143
         assert text_doc.meta['type'] == 'text'
         assert text_doc.meta['content_type'] == 'text/plain'


### PR DESCRIPTION
For storage objects, the `Document.meta` keys `s3_bucket` and `s3_key` have been refactored to `storage_bucket` and `storage_key`. 

This change does **not** include a migration since the fields are still in `Document.meta` (for this exact type of flexibility). Therefore any existing storage documents will have to be edited to include the new keys.