### PR TITLE
Remove result from task status

### DIFF
--- a/lexy/core/celery_app.py
+++ b/lexy/core/celery_app.py
@@ -34,7 +34,6 @@ def get_task_info(task_id, verbose: bool = False) -> dict:
         "queue": task_result.queue,
         "parent": task_result.parent,
         "children": task_result.children,
-        "info": task_result.info,
     }
     if verbose:
         result["result"] = task_result.result


### PR DESCRIPTION
Remove `info` from task status request since it includes task result which is not JSON serializable. 