### PR TITLE
Fix code search example. Improve transform document endpoint.

### DIFF
--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -133,7 +133,8 @@ These packages will be installed in the `lexyworker` container.
         ```plaintext
         # Extra package requirements for pipelines
         pypdf
-        tree-sitter-languages
+        tree-sitter==0.20.4
+        tree-sitter-languages==1.8.0
         ```
 
 

--- a/examples/code_search.ipynb
+++ b/examples/code_search.ipynb
@@ -481,6 +481,19 @@
    "id": "46d013e37df19179"
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Install tree-sitter-languages if not already installed\n",
+    "! pip install tree-sitter==0.20.4 tree-sitter-languages==1.8.0"
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "42f507d6bcbcabf"
+  },
+  {
    "cell_type": "markdown",
    "source": [
     "Using `tree-sitter-languages`, we come up with the following code to extract comments and docstrings from code for a variety of languages (C++, Python, Typescript, and TSX)."
@@ -734,9 +747,17 @@
   {
    "cell_type": "markdown",
    "source": [
-    "We put the above code into a file called `code.py` and place it inside of the `lexy.transformers` directory. \n",
+    "We put the above code into a file called `code.py` and place it inside the `PIPELINE_DIR` directory.\n",
     "\n",
-    "*Additional instructions...*"
+    "We must also include the package requirements in `$PIPELINE_DIR/requirements.txt` in order for the Lexy worker to install the necessary packages.\n",
+    "\n",
+    "Contents of `requirements.txt`:\n",
+    "\n",
+    "```txt\n",
+    "# Extra package requirements for pipelines\n",
+    "tree-sitter==0.20.4\n",
+    "tree-sitter-languages==1.8.0\n",
+    "```"
    ],
    "metadata": {
     "collapsed": false

--- a/lexy/api/endpoints/transformers.py
+++ b/lexy/api/endpoints/transformers.py
@@ -182,6 +182,17 @@ async def transform_document(
         args=[task_arg],
         kwargs=transformer_params,
     )
-    result = task.get()
-    response = {"task_id": task.id, "result": result}
-    return convert_arrays_to_lists(response)
+    result = task.get(propagate=False)
+    if task.state == "FAILURE":
+        # Task failed, extract the exception
+        exception = task.result
+        response = {
+            "task_id": task.id,
+            "error": str(exception),
+            "traceback": task.traceback,
+        }
+        return response
+    else:
+        # Task succeeded
+        response = {"task_id": task.id, "result": result}
+        return convert_arrays_to_lists(response)

--- a/sdk-python/lexy_py/transformer/client.py
+++ b/sdk-python/lexy_py/transformer/client.py
@@ -222,7 +222,7 @@ class TransformerClient:
 
         Returns:
             dict: A dictionary containing the generated task ID and the result of the
-            transformer.
+                transformer.
 
         Examples:
             >>> from lexy_py import LexyClient

--- a/sdk-python/lexy_py/transformer/models.py
+++ b/sdk-python/lexy_py/transformer/models.py
@@ -67,7 +67,7 @@ class Transformer(TransformerModel):
 
         Returns:
             dict: A dictionary containing the generated task ID and the result of the
-            transformer.
+                transformer.
 
         Examples:
             >>> from lexy_py import LexyClient


### PR DESCRIPTION
- Fix `examples/code_search.ipynb` which was failing on `get_language()`.
  - Caused by [issue](https://github.com/grantjenks/py-tree-sitter-languages/issues/64) in `tree-sitter` and `tree-sitter-languages`.
- The `transform_document` endpoint now returns the error message and traceback when a transformer task fails.
  - Was previously throwing a 500.
